### PR TITLE
Update 1-basic-concepts.rst. Add cross-link labels

### DIFF
--- a/Documentation/8-Fluid/1-basic-concepts.rst
+++ b/Documentation/8-Fluid/1-basic-concepts.rst
@@ -315,7 +315,7 @@ on. We can thus confirm that you can process the value of every Object
 Accessor by inserting it into the ViewHelper with the help of the chaining
 operator (->) . This can also be done multiple times.
 
-.. _inline-notation-vs-tag-based-notation
+.. _inline-notation-vs-tag-based-notation:
 
 .. sidebar:: Inline Notation vs. Tag Based Notation
 


### PR DESCRIPTION
Allow to cross-link to basic-concepts chapter using :ref:`title <basic-concepts>` .
Allow to cross-link to inline-notation-vs-tag-based-notation sidebar box using e.g. :ref:`inline-notation-vs-tag-based-notation` (or providing a title see above).
