### PR TITLE
[CLEANUP] Remove old code syntax

### DIFF
--- a/Documentation/0-Introduction/4-typographic-conventions.rst
+++ b/Documentation/0-Introduction/4-typographic-conventions.rst
@@ -9,7 +9,7 @@ This book uses the following typographic conventions:
 
 :class:`class names`,
 
-:code:`method names`,
+`method names`,
 
 ``inline code``
 

--- a/Documentation/3-BlogExample/4-and-action.rst
+++ b/Documentation/3-BlogExample/4-and-action.rst
@@ -10,7 +10,7 @@ In software development, there are different variants of controllers.
 In Extbase the controllers mostly exist as
 :class:`ActionController`. This variant is characterized by
 short methods, which are responsible for the control of a single action, the
-so called :code:`Actions`. Let's have a deeper look at a
+so called `Actions`. Let's have a deeper look at a
 shortened version of the :class:`BlogController`:
 
 ::
@@ -49,36 +49,36 @@ shortened version of the :class:`BlogController`:
 
     }
 
-The method :code:`indexAction()` within the
+The method `indexAction()` within the
 :class:`BlogController` is responsible for showing a list of
 blogs. We also could have called it
-:code:`showMeTheListAction()`. The only important point is,
-that it ends with :code:`Action` in order to help Extbase
-to recognize it as an action. :code:`newAction()` shows a
-form to create a new blog. The :code:`createAction()` then
+`showMeTheListAction()`. The only important point is,
+that it ends with `Action` in order to help Extbase
+to recognize it as an action. `newAction()` shows a
+form to create a new blog. The `createAction()` then
 creates a new blog with the data of the form. The pair
-:code:`editAction()` and
-:code:`updateAction()` have a similar functionality for the
+`editAction()` and
+`updateAction()` have a similar functionality for the
 change of an existing blog. The job of the
-:code:`deleteAction()` should be self explaining.
+`deleteAction()` should be self explaining.
 
 .. tip::
 
-	Who already dealed with the model-view-controller-pattern will
-	notice, that the controller has only a little amount of code. Extbase (and
-	FLOW3) aim to the approach to have a slim controller. The controller is
-	exclusively responsible for the control of the process flow. Additional
-	logic (especially business or domain logic) needs to be seperated into
-	classes in the subfolder :file:`Domain`.
+    Who already dealed with the model-view-controller-pattern will
+    notice, that the controller has only a little amount of code. Extbase (and
+    FLOW3) aim to the approach to have a slim controller. The controller is
+    exclusively responsible for the control of the process flow. Additional
+    logic (especially business or domain logic) needs to be seperated into
+    classes in the subfolder :file:`Domain`.
 
 .. tip::
 
-	The name of the action is strictly spoken only the part without the
-	suffix :code:`Action`, e.g.
-	:code:`list`, :code:`show` or
-	:code:`edit`. With the suffix
-	:code:`Action` the name of the action-method is marked.
-	But we use the action itself and its method mostly synonymous.
+    The name of the action is strictly spoken only the part without the
+    suffix `Action`, e.g.
+    `list`, `show` or
+    `edit`. With the suffix
+    `Action` the name of the action-method is marked.
+    But we use the action itself and its method mostly synonymous.
 
 From the request the controller can extract which action has to be
 called. The call is happening without the need to write another line of code
@@ -94,8 +94,8 @@ class:
 
 At first call of the plugin without additional information the request
 will get a standard action; in our case the
-:code:`indexAction()`. The
-:code:`indexAction()` contains only one line in our example
+`indexAction()`. The
+`indexAction()` contains only one line in our example
 (as shown above), which looks more detailled like this:
 
 ::
@@ -120,5 +120,5 @@ class file. The name :class:`BlogRepository` results from the
 name of the class, whose instances are managed by the repository, namely by
 adding :class:`Repository`. A repository can only manage one
 single class at a time. The second line retrieves all available blogs by
-:code:`findAll()`.
+`findAll()`.
 

--- a/Documentation/3-BlogExample/7-Paths-on-the-Data-Map.rst
+++ b/Documentation/3-BlogExample/7-Paths-on-the-Data-Map.rst
@@ -1,12 +1,12 @@
 Paths on the Data-Map
 =====================
 
-The :code:`DataMapper` object has the task to create an instance of the Blog-Class
-(whose name is stored in :code:`$this->className`) for each tuple and "fill" this fresh
-instance with the data of the tuple. It is called in the :code:`Query` object by the
+The `DataMapper` object has the task to create an instance of the Blog-Class
+(whose name is stored in `$this->className`) for each tuple and "fill" this fresh
+instance with the data of the tuple. It is called in the `Query` object by the
 following Lines::
 
-	$this->dataMapper->map($this->getType(), $rows);
+    $this->dataMapper->map($this->getType(), $rows);
 
 The ``DataMapper`` object also resolves all relations. This means that it starts
 requests for the posts and builds the objects with all included sub objects
@@ -23,19 +23,19 @@ property *posts* within the ``Blog`` class. You can find this in the file
 
 ::
 
-	class Tx_BlogExample_Domain_Model_Blog extends Tx_Extbase_DomainObject_AbstractEntity {
-		...
+    class Tx_BlogExample_Domain_Model_Blog extends Tx_Extbase_DomainObject_AbstractEntity {
+        ...
 
-		/**
-		 * The posts of this blog
-		 *
-		 * @var Tx_Extbase_Persistence_ObjectStorage<Tx_BlogExample_Domain_Model_post>
-		 *
-		 */
-		protected $posts;
+        /**
+         * The posts of this blog
+         *
+         * @var Tx_Extbase_Persistence_ObjectStorage<Tx_BlogExample_Domain_Model_post>
+         *
+         */
+        protected $posts;
 
-		...
-	}
+        ...
+    }
 
 
 The property ``$posts`` contains within the PHP comment above some so called
@@ -43,7 +43,7 @@ annotations which start with the @ character. The annotation:
 
 ::
 
-	@var Tx_Extbase_Persistence_ObjectStorage<Tx_BlogExample_Domain_Model_Post>
+    @var Tx_Extbase_Persistence_ObjectStorage<Tx_BlogExample_Domain_Model_Post>
 
 
 tells the ``DataMapper`` to create an ``ObjectStorage`` there and fill it with the
@@ -51,15 +51,15 @@ tells the ``DataMapper`` to create an ``ObjectStorage`` there and fill it with t
 
 .. note::
 
-	The :class:`Tx_Extbase_Persistence_ObjectStorage` is a class of Extbase. This
-	class takes objects and ensures that an instance is unique within the
-	``ObjectStorage``. Objects within the ``ObjectStorage`` can be accessed by the
-	methods ``attach()``, ``detach()`` and ``contains()`` amongst others. The
-	``ObjectStorage`` also implements the interfaces ``Iterator``, ``Countable``,
-	``ArrayAccess``. So it is usable in ``foreach`` constructs.
-	Furthermore the ``ObjectStorage`` behaves like an array. The ``ObjectStorage``
-	of Extbase is based upon the native ``SplObjectStorage`` of PHP, which is error
-	free since PHP-Version 5.3.1.
+    The :class:`Tx_Extbase_Persistence_ObjectStorage` is a class of Extbase. This
+    class takes objects and ensures that an instance is unique within the
+    ``ObjectStorage``. Objects within the ``ObjectStorage`` can be accessed by the
+    methods ``attach()``, ``detach()`` and ``contains()`` amongst others. The
+    ``ObjectStorage`` also implements the interfaces ``Iterator``, ``Countable``,
+    ``ArrayAccess``. So it is usable in ``foreach`` constructs.
+    Furthermore the ``ObjectStorage`` behaves like an array. The ``ObjectStorage``
+    of Extbase is based upon the native ``SplObjectStorage`` of PHP, which is error
+    free since PHP-Version 5.3.1.
 
 
 The notation at first seems unusual. It is based on the so called *Generics* of
@@ -69,30 +69,30 @@ PHP-type will look like this:
 
 ::
 
-	/**
-	 * @var int
-	 */
-	protected $amount;
+    /**
+     * @var int
+     */
+    protected $amount;
 
 
 It is also possible to enter a class as type:
 
 ::
 
-	/**
-	 * @var Tx_BlogExample_Domain_Model_Author
-	 */
-	protected $author;
+    /**
+     * @var Tx_BlogExample_Domain_Model_Author
+     */
+    protected $author;
 
 
 Properties which should be bound to multiple child objects require the class name of the child elements in angle brackets:
 
 ::
 
-	/**
-	 * @var Tx_Extbase_Persistence_ObjectStorage<Tx_BlogExample_Domain_model_Tags>
-	 */
-	protected $tags;
+    /**
+     * @var Tx_Extbase_Persistence_ObjectStorage<Tx_BlogExample_Domain_model_Tags>
+     */
+    protected $tags;
 
 
 Extbase gathers the type of the relation from the configuration of the database
@@ -101,28 +101,28 @@ found in the file :file:`tca.php` within the path *Configuration/TCA/*.
 
 ::
 
-	$TCA['tx_blogexample_domain_model_blog'] = array(
-		...
-		'columns' => array(
-			...
-			'posts' => array(
-				'exclude' => 1,
-				'label' => 'LLL:EXT:blog_example/Resources/Private/Language/locallang_db.xml:tx_blogexample_domain_model_blog.posts',
-				'config' => array(
-					'type' => 'inline',
-					'foreign_table' => 'tx_blogexample_domain_model_post',
-					'foreign_field' => 'blog',
-					'foreign_sortby' => 'sorting',
-					'maxitems' => 999999,
-					'appearance' => array(
-						'newRecordLinkPosition' => 'bottom',
-						'collapseAll' => 1,
-						'expandSingle' => 1,
-					),
-				)
-			),
-			...
-	);
+    $TCA['tx_blogexample_domain_model_blog'] = array(
+        ...
+        'columns' => array(
+            ...
+            'posts' => array(
+                'exclude' => 1,
+                'label' => 'LLL:EXT:blog_example/Resources/Private/Language/locallang_db.xml:tx_blogexample_domain_model_blog.posts',
+                'config' => array(
+                    'type' => 'inline',
+                    'foreign_table' => 'tx_blogexample_domain_model_post',
+                    'foreign_field' => 'blog',
+                    'foreign_sortby' => 'sorting',
+                    'maxitems' => 999999,
+                    'appearance' => array(
+                        'newRecordLinkPosition' => 'bottom',
+                        'collapseAll' => 1,
+                        'expandSingle' => 1,
+                    ),
+                )
+            ),
+            ...
+    );
 
 Extbase "reads" from the configuration the table of the child objects
 (``foreign_table``) and the key field where the unique identifier (UID) of the

--- a/Documentation/4-FirstExtension/3-create-the-domain-model.rst
+++ b/Documentation/4-FirstExtension/3-create-the-domain-model.rst
@@ -13,12 +13,12 @@ This class file is stored in the folder
 
 .. tip::
 
-	The labels of the classes always must reflect the folder structure.
-	For example extbase expects the class
-	:class:`Tx_MyExtension_FirstFolder_SecondFolder_File` in the
-	folder
-	:file:`my_extension/Classes/FirstFolder/SecondFolder/File.php`.
-	Pay attention to the corresponding upper case of the folder names.
+    The labels of the classes always must reflect the folder structure.
+    For example extbase expects the class
+    :class:`Tx_MyExtension_FirstFolder_SecondFolder_File` in the
+    folder
+    :file:`my_extension/Classes/FirstFolder/SecondFolder/File.php`.
+    Pay attention to the corresponding upper case of the folder names.
 
 Below we have a view into this file, note that the class
 :class:`Tx_Inventory_Domain_Model_Product` must be derivated
@@ -27,90 +27,90 @@ from the extbase class
 
 ::
 
-	<?php
-	class Tx_Inventory_Domain_Model_Product extends Tx_Extbase_DomainObject_AbstractEntity {
-	/**
-	 * @var string
-	 **/
-	protected $name = '';
+    <?php
+    class Tx_Inventory_Domain_Model_Product extends Tx_Extbase_DomainObject_AbstractEntity {
+    /**
+     * @var string
+     **/
+    protected $name = '';
 
-	/**
-	 * @var string
-	 **/
-	protected $description = '';
+    /**
+     * @var string
+     **/
+    protected $description = '';
 
-	/**
-	 * @var int
-	 **/
-	protected $quantity = 0;
+    /**
+     * @var int
+     **/
+    protected $quantity = 0;
 
-	public function __construct($name = '', $description = '', $quantity = 0) {
-		$this->setName($name);
-		$this->setDescription($description);
-		$this->setQuantity($quantity);
-	}
+    public function __construct($name = '', $description = '', $quantity = 0) {
+        $this->setName($name);
+        $this->setDescription($description);
+        $this->setQuantity($quantity);
+    }
 
-	public function setName($name) {
-		$this->name = (string)$name;
-	}
+    public function setName($name) {
+        $this->name = (string)$name;
+    }
 
-	public function getName() {
-		return $this->name;
-	}
+    public function getName() {
+        return $this->name;
+    }
 
-	public function setDescription($description) {
-		$this->description = (string)$description;
-	}
+    public function setDescription($description) {
+        $this->description = (string)$description;
+    }
 
-	public function getDescription() {
-		return $this->description;
-	}
+    public function getDescription() {
+        return $this->description;
+    }
 
-	public function setQuantity($quantity) {
-		$this->quantity = (int)$quantity;
-	}
+    public function setQuantity($quantity) {
+        $this->quantity = (int)$quantity;
+    }
 
-	public function getQuantity() {
-		return $this->quantity;
-	}
+    public function getQuantity() {
+        return $this->quantity;
+    }
 
-	}
-	?>
+    }
+    ?>
 
 The product properties are designed as class variable
 ``$name``, ``$description`` and ``$quantity`` and
 protected (*encapsulated*) against direct access from
 outside by the keyword ``protected`` . The property values can be
-set and/or read only by the methods :code:`setProperty()`
-and :code:`getProperty()` declared as ``public``.
+set and/or read only by the methods `setProperty()`
+and `getProperty()` declared as ``public``.
 Methods in this form are used very frequently and therefore they are
 generically named Getter and Setter for short.
 
 .. tip::
 
-	At a first view, the methods appear to be cumbersome for accessing
-	the class variables. However, they have several advantages: The Internals
-	of the processing can be added or changed at a later time, without needing
-	to make changes to the calling object. Also, for example, the reading can
-	be permitted, without simultaneously allowing writing access. Later on,
-	the tedious work needed to code these methods will be made for you by the
-	Kickstarter. Moreover, most development environments offer macros or
-	snippets for this purpose. Note that in different moments Extbase
-	internally tries to fill a property ``$name`` over a method
-	``setName()``.
+    At a first view, the methods appear to be cumbersome for accessing
+    the class variables. However, they have several advantages: The Internals
+    of the processing can be added or changed at a later time, without needing
+    to make changes to the calling object. Also, for example, the reading can
+    be permitted, without simultaneously allowing writing access. Later on,
+    the tedious work needed to code these methods will be made for you by the
+    Kickstarter. Moreover, most development environments offer macros or
+    snippets for this purpose. Note that in different moments Extbase
+    internally tries to fill a property ``$name`` over a method
+    ``setName()``.
 
-The method :code:`__construct()` serves to guarantee
+The method `__construct()` serves to guarantee
 a well defined state at the beginning of the life cycle of the object. Here
 the properties of the product are set with their respectively preset
 values.
 
 .. warning::
-	In the declaration of the constructor, the argument
-	``$name`` is set with a default value (empty string) and
-	thereupon optional. That is necessary so that Extbase can instantiate the
-	class "empty" without a name must be delivered. With this Extbase offends
-	against the pure doctrine because the constructor actually should
-	guarantee the minimal configuration of the object
-	*Organization*. In Extbase, This however better is done
-	with so-called validators (see the section "validating domain objects" in
-	chapter 9).
+    In the declaration of the constructor, the argument
+    ``$name`` is set with a default value (empty string) and
+    thereupon optional. That is necessary so that Extbase can instantiate the
+    class "empty" without a name must be delivered. With this Extbase offends
+    against the pure doctrine because the constructor actually should
+    guarantee the minimal configuration of the object
+    *Organization*. In Extbase, This however better is done
+    with so-called validators (see the section "validating domain objects" in
+    chapter 9).

--- a/Documentation/7-Controllers/1-Creating-Controllers-and-Actions.rst
+++ b/Documentation/7-Controllers/1-Creating-Controllers-and-Actions.rst
@@ -16,9 +16,9 @@ part of Extbase. The individual Actions are combined in seperate methods.
 The method names have to end in :class:`Action`. The body of
 :class:`OfferController` thus looks like this::
 
-	class Tx_SjrOffers_Controller_OfferController extends Tx_Extbase_MVC_Controller_ActionController {
-		// Action methods will be following here
-	}
+    class Tx_SjrOffers_Controller_OfferController extends Tx_Extbase_MVC_Controller_ActionController {
+        // Action methods will be following here
+    }
 
 When realizing the desired tasks through *Action*
 methods you will often stumble upon very similar flows and patterns. Each
@@ -37,10 +37,10 @@ generate your own Flows.
 
 .. tip::
 
-	Note that you are free to choose the method names for your
-	*Actions* as you like. Nevertheless we recommend to
-	stick to the names presented here, to help other Developers to find
-	their way through your Code.
+    Note that you are free to choose the method names for your
+    *Actions* as you like. Nevertheless we recommend to
+    stick to the names presented here, to help other Developers to find
+    their way through your Code.
 
 
 Flow Pattern "display a list of Domain Objects"
@@ -48,35 +48,35 @@ Flow Pattern "display a list of Domain Objects"
 
 The first pattern in our example fits the Action "*display
 a list of all offers*". One Action Method usually will be enough
-for implementing This. we choose :code:`indexAction` as
+for implementing This. we choose `indexAction` as
 name of the Method::
 
-	public function indexAction() {
+    public function indexAction() {
 
-		$offerRepository = t3lib_div_makeInstance('Tx_SjrOffers_Domain_Repository_OfferRepository');
+        $offerRepository = t3lib_div_makeInstance('Tx_SjrOffers_Domain_Repository_OfferRepository');
 
-		$offers = $offerRepository->findAll();
+        $offers = $offerRepository->findAll();
 
-		$this->view->assign('offers', $offers);
+        $this->view->assign('offers', $offers);
 
-		return $this->view->render();
+        return $this->view->render();
 
-	}
+    }
 
 This can be simplified even more. As described in chapter 4 in
 section "controlling the flow", it is not necessary to return the rendered
 content. Furthermore we avoid initializing the variable
-:code:`$offers`, which we only use once. So we
+`$offers`, which we only use once. So we
 get::
 
-	public function indexAction() {
+    public function indexAction() {
 
-		$offerRepository =
-		t3lib_div_makeInstance('Tx_SjrOffers_Domain_Repository_OfferRepository');
+        $offerRepository =
+        t3lib_div_makeInstance('Tx_SjrOffers_Domain_Repository_OfferRepository');
 
-		$this->view->assign('offers', $offerRepository->findAll());
+        $this->view->assign('offers', $offerRepository->findAll());
 
-	}
+    }
 
 This Flow is prototypic for a task which merely has to give out
 data. Domain Objects are fetched from a Repository previously instatiated
@@ -93,16 +93,16 @@ our case we assign the instance of our Repository to the Class Variable
 :class:`$offerRepository`. Our Controller thus looks like
 this::
 
-	protected $offerRepository;
+    protected $offerRepository;
 
-	public function initializeAction() {
-		$this->offerRepository =
-		t3lib_div::makeInstance('Tx_JjrOffers_Domain_Repository_OfferRepository');
-	}
+    public function initializeAction() {
+        $this->offerRepository =
+        t3lib_div::makeInstance('Tx_JjrOffers_Domain_Repository_OfferRepository');
+    }
 
-	public function indexAction() {
-		$this->view->assign('offers', $this->offerRepository->findAll());
-	}
+    public function indexAction() {
+        $this->view->assign('offers', $this->offerRepository->findAll());
+    }
 
 :class:`ActionController` not only calls hte Method
 :class:`initializeAction()`, which is executed before any
@@ -116,9 +116,9 @@ or to check if a specific FE user is logged in.
 
 .. tip::
 
-	The trick of implementing an empty Method body in the super
-	class, which is the "filled" in the subclass is called
-	*Template Pattern*.
+    The trick of implementing an empty Method body in the super
+    class, which is the "filled" in the subclass is called
+    *Template Pattern*.
 
 
 
@@ -131,14 +131,14 @@ well. We call it :class:`showAction()`. In contrast to
 outside which Domain Object is to be displayed. In our case, the offer to
 be shown is passed to the Method as Argument::
 
-	/**
-	 * @param Tx_SjrOffers_Domain_Model_Offer $offer The offer to be shown
-	 * @return string The rendered HTML string
-	 */
+    /**
+     * @param Tx_SjrOffers_Domain_Model_Offer $offer The offer to be shown
+     * @return string The rendered HTML string
+     */
 
-	public function showAction(Tx_SjrOffers_Domain_Model_Offer $offer) {
-		$this->view->assign('offer', $offer);
-	}
+    public function showAction(Tx_SjrOffers_Domain_Model_Offer $offer) {
+        $this->view->assign('offer', $offer);
+    }
 
 Ususally the display of a single Object is called by a link in
 Forntend. In our example extension it connects the list view by something
@@ -183,10 +183,10 @@ to the view, which is taking care of the HTML output as usual.
 
 .. tip::
 
-	Inside of the Template you can access all Properties of the
-	Domain Object, including all existing child objects. Thus this Flow
-	Pattern does not only cover single Domain Objects but, in the event,
-	also a complex Aggregate.
+    Inside of the Template you can access all Properties of the
+    Domain Object, including all existing child objects. Thus this Flow
+    Pattern does not only cover single Domain Objects but, in the event,
+    also a complex Aggregate.
 
 If an Argument is identified as invalid, the already implemented
 Method :class:`errorAction()` of
@@ -211,10 +211,10 @@ Repository. We're going to implement these two steps in the Methods
 
 .. tip::
 
-	We already described these steps in chapter 3 in section
-	"Alternative route: creating a new posting". We now shortly revise
-	this Flow using our example extension and focus on some further
-	aspects.
+    We already described these steps in chapter 3 in section
+    "Alternative route: creating a new posting". We now shortly revise
+    this Flow using our example extension and focus on some further
+    aspects.
 
 First the Method :class:`newAction()` is called by a
 Link in frontend with the following URL:
@@ -233,22 +233,22 @@ Method :class:`newAction()`.
 
 ::
 
-	/**
-	 * @param Tx_SjrOffers_Domain_Model_Organization $organization The organization
-	 * @param Tx_SjrOffers_Domain_Model_Offer $offer The new offer object
-	 * @return string An HTML form for creating a new offer
-	 * @dontvalidate $newOffer
-	 */
+    /**
+     * @param Tx_SjrOffers_Domain_Model_Organization $organization The organization
+     * @param Tx_SjrOffers_Domain_Model_Offer $offer The new offer object
+     * @return string An HTML form for creating a new offer
+     * @dontvalidate $newOffer
+     */
 
-	public function	newAction(Tx_SjrOffers_Domain_Model_Organization $organization,
-	Tx_SjrOffers_Domain_Model_Offer $newOffer = NULL) {
+    public function newAction(Tx_SjrOffers_Domain_Model_Organization $organization,
+    Tx_SjrOffers_Domain_Model_Offer $newOffer = NULL) {
 
-		$this->view->assign('organization',$organization);
+        $this->view->assign('organization',$organization);
 
-		$this->view->assign('newOffer',$newOffer);
+        $this->view->assign('newOffer',$newOffer);
 
-		$this->view->assign('regions',$this->regionRepository->findAll());
-	}
+        $this->view->assign('regions',$this->regionRepository->findAll());
+    }
 
 This Action passes to the view: in
 :class:`organization` the :class:`Organization
@@ -350,8 +350,8 @@ deliberately attack the website?
 
 .. tip::
 
-	You find detailed information about validation and security in
-	chapter 9
+    You find detailed information about validation and security in
+    chapter 9
 
 Fluid adds multiple hidden fields to the form generated by the
 Method :class:`newAction()`. These contain information about
@@ -376,16 +376,16 @@ data is put in the fields again and the previously saved error message is
 displayed if the template is intenting so.
 
 .. figure:: /Images/7-Controllers/figure-7-1.png
-	:align: center
+    :align: center
 
-	Figure 7-1: Wrong input in the form of an offer leads to an error mesage
-	(in this case a modal JavaScript window)
+    Figure 7-1: Wrong input in the form of an offer leads to an error mesage
+    (in this case a modal JavaScript window)
 
 .. tip::
 
-	Standard error messages of Extbase are not yet localized in
-	Version 1.2. In section "Localize error messages" in chapter 8, we
-	describe a possibility to translate them too, though.
+    Standard error messages of Extbase are not yet localized in
+    Version 1.2. In section "Localize error messages" in chapter 8, we
+    describe a possibility to translate them too, though.
 
 Using the hidden field :class:`__hmac`, Extbase
 compares in an early stage the structure of a form inbetween delivery to
@@ -435,11 +435,11 @@ new request is started and the organization is shown with its updated
 offers.
 
 .. warning::
-	Do not forget to expicitly update the changed Domain Object
-	using :class:`update()`. Extbase will not do this
-	automatically for you, for doing so could lead to unexpected results.
-	For example if you have to manipulate the incoming Domain Object
-	inside your Action Method.
+    Do not forget to expicitly update the changed Domain Object
+    using :class:`update()`. Extbase will not do this
+    automatically for you, for doing so could lead to unexpected results.
+    For example if you have to manipulate the incoming Domain Object
+    inside your Action Method.
 
 At this point we have to ask ourselves how to prevent
 unauthorized changes of our Domain data. The organization and offer data
@@ -491,30 +491,30 @@ this snippet from a template:
 
 .. tip::
 
-	A *Service* is often used to implement
-	functionalitites that are needed on mulitple places in your extensions
-	and are not related to one Domain Object.
+    A *Service* is often used to implement
+    functionalitites that are needed on mulitple places in your extensions
+    and are not related to one Domain Object.
 
-	Services are often stateless. In this context that means that
-	their function does not dependend on previous access. This does not
-	rule out dependency to the "environment". In our example you can be
-	sure, that a verification by :class:`isLoggendIn()`
-	always leads to the same result, regardless of any earlier
-	verification - given that the "environment" has not changed
-	(considerably), e.g. by the Administrator logging out or even losing
-	his acces rights.
+    Services are often stateless. In this context that means that
+    their function does not dependend on previous access. This does not
+    rule out dependency to the "environment". In our example you can be
+    sure, that a verification by :class:`isLoggendIn()`
+    always leads to the same result, regardless of any earlier
+    verification - given that the "environment" has not changed
+    (considerably), e.g. by the Administrator logging out or even losing
+    his acces rights.
 
-	Services usually can be built as *Singleton*
-	(:class:`implements t3lib_Singleton`). You can find
-	detailed information to *Singleton* in chapter 2 in
-	section "Singleton".
+    Services usually can be built as *Singleton*
+    (:class:`implements t3lib_Singleton`). You can find
+    detailed information to *Singleton* in chapter 2 in
+    section "Singleton".
 
-	The :class:`AccessControlService` is not Part of
-	the Domain of our extension. It "belongs" to the Domain of the Content
-	Management System. There are Domain Services also of course, like a
-	Service creating a continuous invoice number. They are usually located
-	in <link
-	linkend="???">EXT:my_ext/Classes/Domain/Service/</link>.
+    The :class:`AccessControlService` is not Part of
+    the Domain of our extension. It "belongs" to the Domain of the Content
+    Management System. There are Domain Services also of course, like a
+    Service creating a continuous invoice number. They are usually located
+    in <link
+    linkend="???">EXT:my_ext/Classes/Domain/Service/</link>.
 
 We make use of an :class:`IfAuthenticatedViewHelper`
 to acces the :class:`AccessControlService`. The class file
@@ -550,11 +550,11 @@ the Database respectively mark it as deleted.
 
 .. tip::
 
-	In principle it doesn't matter how you generate the result
-	(usually HTML code) inside the Action. You can even decide to use the
-	traditional way of building extensions in your Action - with SQL
-	Queries and maker-based Templating. We invite you to pursue the path
-	we chose up till now, though.
+    In principle it doesn't matter how you generate the result
+    (usually HTML code) inside the Action. You can even decide to use the
+    traditional way of building extensions in your Action - with SQL
+    Queries and maker-based Templating. We invite you to pursue the path
+    we chose up till now, though.
 
 The flow patterns we present here are meant to be blueprints for
 your own flows. In real life projects they may get way more complex. The
@@ -577,25 +577,25 @@ correct section name</remark>). To define his demand, the visitor chooses
 the accordant options in a form (see pic. 7-2).
 
 .. figure:: /Images/7-Controllers/figure-7-2.png
-	:align: center
+    :align: center
 
-	Figure 7-2: The buildup of the "demand" in a form above the offer list.
+    Figure 7-2: The buildup of the "demand" in a form above the offer list.
 
 .. warning::
-	Watch out, that you do not implement logic, which actually
-	belongs in the domain, inside of the Controller. Concentrate on the
-	mere Flow.
+    Watch out, that you do not implement logic, which actually
+    belongs in the domain, inside of the Controller. Concentrate on the
+    mere Flow.
 
 .. tip::
 
-	In real life you will often need similar functionality in some
-	or even all Controllers, the previously mentioned access control is a
-	good example. In our example extension we sourced it out to a
-	*service* object. Another possibility is to create
-	a basis Controller which extends the
-	:class:`ActionController` of Extbase. Inside you
-	implement the shared functionality. Then the concrete controllers with
-	you Actions extend this Basis Controller again.
+    In real life you will often need similar functionality in some
+    or even all Controllers, the previously mentioned access control is a
+    good example. In our example extension we sourced it out to a
+    *service* object. Another possibility is to create
+    a basis Controller which extends the
+    :class:`ActionController` of Extbase. Inside you
+    implement the shared functionality. Then the concrete controllers with
+    you Actions extend this Basis Controller again.
 
 The Flow inside of a Controller is triggered from outside by
 TYPO3. For extensions which generate content for the frontend, this is

--- a/Documentation/8-Fluid/1-basic-concepts.rst
+++ b/Documentation/8-Fluid/1-basic-concepts.rst
@@ -25,10 +25,10 @@ Accessors*.
 
 .. tip::
 
-	The markers used in the classic marker based templates of TYPO3 v4
-	are also placeholders which are replaced later on by the desired data.
-	You will notice though, that the placeholders used in Fluid are clearly
-	more flexible and versatile.
+    The markers used in the classic marker based templates of TYPO3 v4
+    are also placeholders which are replaced later on by the desired data.
+    You will notice though, that the placeholders used in Fluid are clearly
+    more flexible and versatile.
 
 Object Accessors are written in curly brackets. For example,
 ``{blogTitle}`` will output the content of the variable
@@ -38,23 +38,23 @@ object)``. Let us look at this in an example of a list of blog posts.
 In the controller, we assign some data to the template with the following
 code::
 
-	class Tx_BlogExample_Controller_PostController extends Tx_Extbase_MVC_Controller_ActionController {
-		...
-		public function indexAction(Tx_BlogExample_Domain_Model_Blog $blog) {
-			$this->view->assign('blogTitle', 'Webdesign-Blog');
-			$this->view->assign('blogPosts', $blog->getPosts());
-		}
-	}
+    class Tx_BlogExample_Controller_PostController extends Tx_Extbase_MVC_Controller_ActionController {
+        ...
+        public function indexAction(Tx_BlogExample_Domain_Model_Blog $blog) {
+            $this->view->assign('blogTitle', 'Webdesign-Blog');
+            $this->view->assign('blogPosts', $blog->getPosts());
+        }
+    }
 
 Now we can insert the string »Webdesign-Blog« into the
 template with the Object Accessor ``{blogTitle}``. Let us take a
 look at the associated template::
 
-	<h1>{blog.Title}</h1>
+    <h1>{blog.Title}</h1>
 
-	<f:for each="{blogPost}" as="post">
-		<b>{post.title}</b><br />
-	</f:for>
+    <f:for each="{blogPost}" as="post">
+        <b>{post.title}</b><br />
+    </f:for>
 
 Upon generation of the output, the Object
 Accessor ``{blogTitle}`` will be replaced by the title of the
@@ -63,18 +63,18 @@ blog »Webdesign-Blog«. To output the individual blog posts, the tag
 above. Depending on the title of each blog post, the complete output looks
 like this::
 
-	<h1>Webdesign-Blog</h1>
+    <h1>Webdesign-Blog</h1>
 
-	<b>Fluid as template-engine</b><br />
-	<b>TypoScript to configure TYPO3</b><br />
+    <b>Fluid as template-engine</b><br />
+    <b>TypoScript to configure TYPO3</b><br />
 
 
 
 .. tip::
 
-	If you want to output an object instead of a String, the object
-	needs to have a ``__toString()``-method which returns the
-	textual representation of the object.
+    If you want to output an object instead of a String, the object
+    needs to have a ``__toString()``-method which returns the
+    textual representation of the object.
 
 In the example above, you will also find the Object Accessor
 ``{post.title}`` which is used to output the title of a blog
@@ -88,7 +88,7 @@ in the following order:
 
 * If ``post`` is an array or an object which implements the interface ArrayAccess,
   the corresponding property will be returned as long as it exists.
-* If it is an object, and a method :code:`getTitle()` exists,
+* If it is an object, and a method `getTitle()` exists,
   the method will be called. This is the most common use case of an Object Accessor,
   since by convention all public properties have a corresponding ``get``-method.
 * The property will be returned if it exists in the object and it
@@ -97,18 +97,18 @@ in the following order:
 
 .. sidebar:: The Uniform Access Principle
 
-	The Uniform Access Principle says, all services offered by a
-	module should be available through an uniform notation which does not
-	betray whether they are implemented through storage or through
-	computation. <remark>Explanation on Wiki</remark>
+    The Uniform Access Principle says, all services offered by a
+    module should be available through an uniform notation which does not
+    betray whether they are implemented through storage or through
+    computation. <remark>Explanation on Wiki</remark>
 
-	Stored objects are being accessed directly using public class
-	variables in PHP - and it is visible on the outside that the object
-	isn't being computed. For this reason, we often use get and
-	set-methods in our models. Therefore, all options of the class are
-	accessible through method calls and are uniformly addressed - it is
-	not visible on the outside whether the class computed or stored the
-	value directly.
+    Stored objects are being accessed directly using public class
+    variables in PHP - and it is visible on the outside that the object
+    isn't being computed. For this reason, we often use get and
+    set-methods in our models. Therefore, all options of the class are
+    accessible through method calls and are uniformly addressed - it is
+    not visible on the outside whether the class computed or stored the
+    value directly.
 
 You can navigate through more complex objects, because Object
 Accessors can be nested multiple times. For example, to output the email
@@ -144,7 +144,7 @@ who work on the same templates.
 The standard ViewHelper of Fluid will be imported and assigned to
 the shortcut ``f`` with the following declaration::
 
-	{namespace f=Tx_Fluid_ViewHelpers}
+    {namespace f=Tx_Fluid_ViewHelpers}
 
 
 This Namespace will be imported automatically by Fluid. All
@@ -159,11 +159,11 @@ Here's a small example:
 
 .. code-block:: none
 
-	<ul>
-		<f:for each="{blogPosts}" as="post">
-			<li>{post.title}</li>
-		</f:for>
-	</ul>
+    <ul>
+        <f:for each="{blogPosts}" as="post">
+            <li>{post.title}</li>
+        </f:for>
+    </ul>
 
 
 
@@ -185,12 +185,12 @@ receives the array of all blog posts with the argument
 
 .. tip::
 
-	If the name of the ViewHelper contains a single or multiple
-	periods, it will be resolved as a sub package. For example, the
-	ViewHelper ``f:form.textbox`` is implemented in the class
-	:class:`Tx_Fluid_ViewHelpers_Form_TextboxViewHelper`.
-	Therefore ViewHelpers can be divided further and structured even
-	more.
+    If the name of the ViewHelper contains a single or multiple
+    periods, it will be resolved as a sub package. For example, the
+    ViewHelper ``f:form.textbox`` is implemented in the class
+    :class:`Tx_Fluid_ViewHelpers_Form_TextboxViewHelper`.
+    Therefore ViewHelpers can be divided further and structured even
+    more.
 
 ViewHelpers are the main tools of template editors. They make it
 possible to have a clear separation of template and embedded
@@ -198,11 +198,11 @@ functionality.
 
 .. tip::
 
-	All control structures like ``if/else`` or
-	``for`` are individual ViewHelpers in Fluid and not a core
-	language feature. This is one of the main reasons for the flexibility
-	of Fluid. You'll find a detailed reference of the ViewHelpers in
-	Appendix C.
+    All control structures like ``if/else`` or
+    ``for`` are individual ViewHelpers in Fluid and not a core
+    language feature. This is one of the main reasons for the flexibility
+    of Fluid. You'll find a detailed reference of the ViewHelpers in
+    Appendix C.
 
 
 Inline Notification for View Helpers
@@ -212,44 +212,44 @@ Inline Notification for View Helpers
 
 .. sidebar:: Inline Notation vs. Tag Based Notation
 
-	Once again a comparison between inline notation and tag based syntax:
+    Once again a comparison between inline notation and tag based syntax:
 
-	Tags have an advantage, if:
+    Tags have an advantage, if:
 
-	* Control structures are being displayed::
+    * Control structures are being displayed::
 
-		<f:for each="{posts}" as="post">...</f:for>
+        <f:for each="{posts}" as="post">...</f:for>
 
-	* The ViewHelper returns a tag::
+    * The ViewHelper returns a tag::
 
-		<f:form.textbox />
+        <f:form.textbox />
 
-	* The hierarchical structure of ViewHelpers is
-	  important::
+    * The hierarchical structure of ViewHelpers is
+      important::
 
-		<f:form>
-			<f:form.textbox />
-		</f:form>
+        <f:form>
+            <f:form.textbox />
+        </f:form>
 
-	* The ViewHelper contains a lot of content::
+    * The ViewHelper contains a lot of content::
 
-		<f:section name="main">
-			....
-	   </f:section>
+        <f:section name="main">
+            ....
+       </f:section>
 
-	Inline notation should be used, if:
+    Inline notation should be used, if:
 
-	* The focus is on the data flow::
+    * The focus is on the data flow::
 
-		{post.date -> f:format.date(format: 'Y-m-d') -> f:format.padding(padLength: 40)}
+        {post.date -> f:format.date(format: 'Y-m-d') -> f:format.padding(padLength: 40)}
 
-	* The ViewHelper is being used inside of XML tags::
+    * The ViewHelper is being used inside of XML tags::
 
-		<link rel="stylesheet" href="{f:uri.resource(path: 'styles.css')}" />
+        <link rel="stylesheet" href="{f:uri.resource(path: 'styles.css')}" />
 
-	* The nature of the ViewHelper is rather a helper function::
+    * The nature of the ViewHelper is rather a helper function::
 
-		{f:translate(key: '...')}
+        {f:translate(key: '...')}
 
 
 It is intuitive and natural for most of the ViewHelpers to be called
@@ -262,7 +262,7 @@ ViewHelper, which returns the path to a resource in the
 inside of ``<link rel="stylesheet" href="..." />`` for
 example. Using the normal, tag based syntax it looks like this::
 
-	<link rel="stylesheet" href="<f:uri.resource path='myCss.css' />" />
+    <link rel="stylesheet" href="<f:uri.resource path='myCss.css' />" />
 
 That is very difficult to read and doesn't communicate adequately
 the meaning of the ViewHelper. Also, the above code is not valid XHTML and
@@ -277,7 +277,7 @@ write ``{f:uri.resource()}``.
 
 So the example above can be changed to::
 
-	<link rel="stylesheet" href="{f:uri.resource(path: 'myCss.css')}" />
+    <link rel="stylesheet" href="{f:uri.resource(path: 'myCss.css')}" />
 
 The purpose of the ViewHelper is easily understandable and visible -
 it is a helper function that returns a resource. It is well formed XHTML
@@ -293,7 +293,7 @@ property *date* which contains the date of the creation
 of the post in a *DateTime* object.
 
 *DateTime* objects, that can be used in PHP to
-represent dates, have no :code:`__toString()`-method and
+represent dates, have no `__toString()`-method and
 can therefore not be outputted with Object Accessors in the template.
 You'll trigger a PHP error message, if you simple write
 ``{post.date}`` in your template.
@@ -311,13 +311,13 @@ that there are no whitespaces or newlines before or after
 ``{post.date}``. If there is, Fluid tries to chain the whitespace
 and the string representation of ``{post.date}`` together as
 string. Because the DateTime object has no method
-:code:`__toString()`, a PHP error message will be thrown
+`__toString()`, a PHP error message will be thrown
 again.
 
 .. tip::
 
-	To avoid this problem, all ``f:format``-ViewHelpers
-	have a property to specify the object to be formatted.
+    To avoid this problem, all ``f:format``-ViewHelpers
+    have a property to specify the object to be formatted.
 
 Instead of writing
 ``<f:format.date>{post.date}</f:format.date>``
@@ -331,7 +331,7 @@ object so we don't add whitespaces inside of
 
 An alternative would be to use the following syntax::
 
-	{post.date -> f:format.date(format: 'Y-m-d')}
+    {post.date -> f:format.date(format: 'Y-m-d')}
 
 Inside the Object Accessor we can use a ViewHelper to process the
 value. The above example is easily readable, intuitive and less error
@@ -339,20 +339,20 @@ prone as the tag based variation.
 
 .. tip::
 
-	This might look familiar, if you happen to know the UNIX shell:
-	There is a pipe operator (|) which has the same functionality as our
-	chaining operator. The arrow shows the direction of the data flow
-	better though.
+    This might look familiar, if you happen to know the UNIX shell:
+    There is a pipe operator (|) which has the same functionality as our
+    chaining operator. The arrow shows the direction of the data flow
+    better though.
 
 You can also chain multiple ViewHelpers together. Lets assume we
 want to pad the processed string to the length of 40 characters (e.g.
 because we output code). This can be simply written as::
 
-	{post.date -> f:format.date(format: 'Y-m-d') -> f:format.padding(padLength: 40)}
+    {post.date -> f:format.date(format: 'Y-m-d') -> f:format.padding(padLength: 40)}
 
 Which is functionally equal to::
 
-	<f:format.padding padLength="40"><f:format.date format="Y-m-d">{post.date}</f:format.date></f:format.padding>
+    <f:format.padding padLength="40"><f:format.date format="Y-m-d">{post.date}</f:format.date></f:format.padding>
 
 The data flow is also easier to read with an inline syntax like
 this, and it is easier to see on which values the ViewHelper is working
@@ -399,14 +399,14 @@ Fluid only supports named arrays, which means, that you always have
 to specify the key of the array element. Lets look at what options you
 have when creating an array::
 
-	{
-		key1: 'Hello',
-		key2: "World",
-		key3: 20,
-		key4: blog,
-		key5: blog.title,
-		key6: '{firstname} {lastname}'
-	}
+    {
+        key1: 'Hello',
+        key2: "World",
+        key3: 20,
+        key4: blog,
+        key5: blog.title,
+        key6: '{firstname} {lastname}'
+    }
 
 The array can contain strings as values as in key1 and key2.
 It can also have numbers as values as in key3. More interesting are key4

--- a/Documentation/9-CrosscuttingConcerns/1-localizing-and-internationalizing-an-extension.rst
+++ b/Documentation/9-CrosscuttingConcerns/1-localizing-and-internationalizing-an-extension.rst
@@ -45,8 +45,8 @@ blog post with its comments there are some constant terms:
 
 .. tip::
 
-	The template is a little bit simplified and reduced to the
-	basic.
+    The template is a little bit simplified and reduced to the
+    basic.
 
 First of all the text "By:" in front of the author of the post is
 hard coded in the template, as well as the caption "Comments". For the use
@@ -92,9 +92,9 @@ in this section. In the above file the texts are stored in two languages:
 
 .. tip::
 
-	The TYPO3 Core API describes in detail the construction of the
-	:file:`locallang.xml` file
-	(*http://typo3.org/documentation/document-library/core-documentation/doc_core_api/4.2.0/view/7/2/*).
+    The TYPO3 Core API describes in detail the construction of the
+    :file:`locallang.xml` file
+    (*http://typo3.org/documentation/document-library/core-documentation/doc_core_api/4.2.0/view/7/2/*).
 
 Now the placeholder for the translated terms must be inserted into
 the template. To do this, Fluid offers the ViewHelper
@@ -103,34 +103,34 @@ the term to be inserted as argument ``key`` and the ViewHelper
 inserts either the german or the english translation according to the
 current language selection ::
 
-	<f:translate key="comment_header" />
-	<!-- or -->
-	{f:translate(key: 'comment_header')}
+    <f:translate key="comment_header" />
+    <!-- or -->
+    {f:translate(key: 'comment_header')}
 
 .. tip::
 
-	The used language is defined in the TypoScript template of the
-	website. By default the english texts are used; but when with setting of
-	the TypoScript setting ``config.language = de`` you can set the
-	used language to german for example.
+    The used language is defined in the TypoScript template of the
+    website. By default the english texts are used; but when with setting of
+    the TypoScript setting ``config.language = de`` you can set the
+    used language to german for example.
 
-	To implement a language selection normally TypoScript conditions
-	are used. These are comparable with an ``if/else``
-	block::
+    To implement a language selection normally TypoScript conditions
+    are used. These are comparable with an ``if/else``
+    block::
 
-		[globalVar = GP:L = 1]
-		config.language = de
-		[else]
-		config.language = default
-		[end]
+        [globalVar = GP:L = 1]
+        config.language = de
+        [else]
+        config.language = default
+        [end]
 
-	When the URL of the website contains a parameter L=1, then the
-	output is in German; if the parameter is not set the output is in the
-	default language English.
+    When the URL of the website contains a parameter L=1, then the
+    output is in German; if the parameter is not set the output is in the
+    default language English.
 
-	With the use of complex TypoScript conditions the language
-	selection could be set to depend on the forwarded language of the
-	browser.
+    With the use of complex TypoScript conditions the language
+    selection could be set to depend on the forwarded language of the
+    browser.
 
 By replacing all terms of the template with the
 ``translate`` ViewHelper we could fit the output of the extension
@@ -142,13 +142,13 @@ english terms:
 
 .. tip::
 
-	Sometimes you have to localize a string in the PHP code, for
-	example in the controller or inside of a ViewHelper. In that case you
-	can use the static method
-	:code:`Tx_Extbase_Utility_Localization::translate($key,
-	$extensionName)`. In addition to the key inside the
-	locallang file also the name of the extension must be given as
-	parameter, in order to load the correct locallang file.
+    Sometimes you have to localize a string in the PHP code, for
+    example in the controller or inside of a ViewHelper. In that case you
+    can use the static method
+    `Tx_Extbase_Utility_Localization::translate($key,
+    $extensionName)`. In addition to the key inside the
+    locallang file also the name of the extension must be given as
+    parameter, in order to load the correct locallang file.
 
 
 Output localized strings using ``sprintf``
@@ -197,15 +197,15 @@ output:
 
 .. tip::
 
-	The keys in the arguments array of the ViewHelper have no
-	relevance. We recommend to give them numbers like the positions
-	(starting with 1), because it is easy understandable.
+    The keys in the arguments array of the ViewHelper have no
+    relevance. We recommend to give them numbers like the positions
+    (starting with 1), because it is easy understandable.
 
 .. tip::
 
-	For a full reference of the formatting options for
-	``sprintf`` you should have a look at the PHP documantation:
-	*http://php.net/manual/de/function.sprintf.php*.
+    For a full reference of the formatting options for
+    ``sprintf`` you should have a look at the PHP documantation:
+    *http://php.net/manual/de/function.sprintf.php*.
 
 Changing localized terms using TypoScript
 --------------------------------------------------------------------------------------------------
@@ -248,13 +248,13 @@ steps based on the ``blog`` class of the blog example. TYPO3
 needs 3 additional database fields which you should insert in the
 :file:`ext_tables.sql` file::
 
-	CREATE TABLE tx_blogexample_domain_model_blog {
-	...
-	sys_language_uid int(11) DEFAULT '0' NOT NULL,
-	l18n_parent int(11) DEFAULT '0' NOT NULL,
-	l18n_diffsource mediumblob NOT NULL,
-	...
-	};
+    CREATE TABLE tx_blogexample_domain_model_blog {
+    ...
+    sys_language_uid int(11) DEFAULT '0' NOT NULL,
+    l18n_parent int(11) DEFAULT '0' NOT NULL,
+    l18n_diffsource mediumblob NOT NULL,
+    ...
+    };
 
 You are free to choose the names of the database fields, but the
 names we use here are common in the world of TYPO3. In any case you have
@@ -264,15 +264,15 @@ the corresponding database table.
 
 ::
 
-	$TCA['tx_blogexample_domain_model_blog'] = array (
-	'ctrl' => array (
-	...
-	'languageField' => 'sys_language_uid',
-	'transOrigPointerField' => 'l18n_parent',
-	'transOrigDiffSourceField' => 'l18n_diffsource',
-	...
-	)
-	);
+    $TCA['tx_blogexample_domain_model_blog'] = array (
+    'ctrl' => array (
+    ...
+    'languageField' => 'sys_language_uid',
+    'transOrigPointerField' => 'l18n_parent',
+    'transOrigDiffSourceField' => 'l18n_diffsource',
+    ...
+    )
+    );
 
 The field ``sys_language_uid`` is used for storing
 the UID of the language in which the blog is written. Based on this UID
@@ -300,12 +300,12 @@ the default language.
 
 .. tip::
 
-	You can control this behavior. If you set the option
-	``config.sys_language_mode`` to ``strict`` in the
-	TypoScript configuration, then only these objects are shown which really
-	have content in the frontend language. More information for this you
-	will find in the *Frontend Localization Guide* of the
-	*Core Documentation*.
+    You can control this behavior. If you set the option
+    ``config.sys_language_mode`` to ``strict`` in the
+    TypoScript configuration, then only these objects are shown which really
+    have content in the frontend language. More information for this you
+    will find in the *Frontend Localization Guide* of the
+    *Core Documentation*.
 
 How TYPO3 v4 handles the localization of content offers two
 important specific features: The first is that all translations of a data
@@ -320,26 +320,26 @@ to create the latter before. But with what content?
 
 .. tip::
 
-	In FLOW3 this is solved better. There only a "structure node"
-	exists to which the content element is added with its different language
-	parts. A default language in this spirit does not exist.
+    In FLOW3 this is solved better. There only a "structure node"
+    exists to which the content element is added with its different language
+    parts. A default language in this spirit does not exist.
 
 Lets have an example for illustration: You create a blog in the
 default language English (=default). It is stored in the database like
 this::
 
-	uid:              7 (given by the database)
-	title:            "My first Blog"
-	sys_language_uid: 0 (selected in backend)
-	l18n_parent:      0 (no tranlation original exists)
+    uid:              7 (given by the database)
+    title:            "My first Blog"
+    sys_language_uid: 0 (selected in backend)
+    l18n_parent:      0 (no tranlation original exists)
 
 After a while you create a German translation in the backend. In the
 database the following record is stored::
 
-	uid:              42 (given by the database)
-	title:            "Mein erster Blog"
-	sys_language_uid: 1 (selected in backend)
-	l18n_parent:      7 (selected in backend respectively given automaticly)
+    uid:              42 (given by the database)
+    title:            "Mein erster Blog"
+    sys_language_uid: 1 (selected in backend)
+    l18n_parent:      7 (selected in backend respectively given automaticly)
 
 A link that references the single view of a blog looks like
 this:
@@ -403,9 +403,9 @@ must be formatted different.
 Generally the date or time is formatted by the
 ``format.date`` ViewHelper::
 
-	<f:format.date date="{dateObject}" format="d.m.Y" />
-	<!-- or -->
-	{dateObject -> f:format.date(format: 'd.m.Y')}
+    <f:format.date date="{dateObject}" format="d.m.Y" />
+    <!-- or -->
+    {dateObject -> f:format.date(format: 'd.m.Y')}
 
 The date object ``{dateObject}`` is displayed with the date
 format given in the parameter ``format``. This format string must
@@ -484,7 +484,7 @@ format string should be used. Here we combine the ``format.date``
 ViewHelper with the ``translate`` ViewHelper which you got to
 know in the section "Multilanguage templates"::
 
-	<f:format.date date="{dateObject}" format="{f:translate(key: 'date_format')}" />
+    <f:format.date date="{dateObject}" format="{f:translate(key: 'date_format')}" />
 
 Than you can store an other format string for every language in the
 :file:`locallang.xml` file and you can change the format
@@ -493,11 +493,11 @@ to know in the section "Multilanguage templates".
 
 .. tip::
 
-	There are other formatting ViewHelpers for adjusting the output of
-	currencies or big numbers. These ViewHelpers all starts with
-	``format``. You can find an overview of these ViewHelpers in
-	Appendix C. These ViewHelpers can be used like the
-	``f:format.date`` ViewHelper you have just learned.
+    There are other formatting ViewHelpers for adjusting the output of
+    currencies or big numbers. These ViewHelpers all starts with
+    ``format``. You can find an overview of these ViewHelpers in
+    Appendix C. These ViewHelpers can be used like the
+    ``f:format.date`` ViewHelper you have just learned.
 
 In this section you have learned how you can translate and localize
 an extension. First we have worked on the localization of single terms in

--- a/Documentation/9-CrosscuttingConcerns/2-validating-domain-objects.rst
+++ b/Documentation/9-CrosscuttingConcerns/2-validating-domain-objects.rst
@@ -46,29 +46,29 @@ settings and poll error messages. We recommend to inherit all validators
 from the
 :class:`Tx_Extbase_Validation_Validator_AbstractValidator`,
 because you get a default implemetation of the helper methods and you only
-have to implement the :code:`isValid()` method.
+have to implement the `isValid()` method.
 
 .. tip::
 
-	You will find the complete reference of the
-	:class:`ValidatorInterface` in Appendix B.
+    You will find the complete reference of the
+    :class:`ValidatorInterface` in Appendix B.
 
 For example, a validator which checks whether the passed string is
 an email address looks like this::
 
-	public function isValid($value) {
-		if (!is_string($value) || !$this->validEmail($value)) {
-			$this->addError(
-				$this->translateErrorMessage(
-					'validator.emailaddress.notvalid',
-					'extbase'
-				), 1221559976);
-		}
-	}
-	
-	protected function validEmail($emailAddress) {
-		return \TYPO3\CMS\Core\Utility\GeneralUtility::validEmail($emailAddress);
-	}
+    public function isValid($value) {
+        if (!is_string($value) || !$this->validEmail($value)) {
+            $this->addError(
+                $this->translateErrorMessage(
+                    'validator.emailaddress.notvalid',
+                    'extbase'
+                ), 1221559976);
+        }
+    }
+    
+    protected function validEmail($emailAddress) {
+        return \TYPO3\CMS\Core\Utility\GeneralUtility::validEmail($emailAddress);
+    }
 
 When ``$value`` is a string that compares to a (complex)
 regular expression, the validator returns ``true``. Otherwise an
@@ -77,11 +77,11 @@ returns ``false``.
 
 .. tip::
 
-	The method ``addError()`` expects an error message and an
-	error code. The latter should be unique, therefore we recommend to use
-	the UNIX timestamp of the creation time of the source code. With the
-	help of the error code the error can be definitely identified, for
-	example in bug reports.
+    The method ``addError()`` expects an error message and an
+    error code. The latter should be unique, therefore we recommend to use
+    the UNIX timestamp of the creation time of the source code. With the
+    help of the error code the error can be definitely identified, for
+    example in bug reports.
 
 As default, extbase will not call your validator if the value to validate is
 empty. This is configued through the property ``$acceptsEmptyValues`` which is
@@ -102,9 +102,9 @@ When they get inserted into a controller action. With the help of figure
 9-1 we can show what happens before the action is called.
 
 .. figure:: /Images/9-CrosscuttingConcerns/figure-9-1.png
-	:align: center
+    :align: center
 
-	Figure 9-1: Data flow of a request before the action is called
+    Figure 9-1: Data flow of a request before the action is called
 
 When a user sends a request, Extbase first determines which action
 respectively controller is responsible for this request. As Extbase knows
@@ -118,30 +118,30 @@ the given objects for example give it to the view for displaying.
 
 .. tip::
 
-	Certainly it would be helpful if the validation is also be done
-	during the persisting of the objects to the database. At the moment it
-	is not done since the data is stored in the database after sending the
-	answer back to the browser. Therefore the user could not be informed in
-	case of validating errors. In the meantime a second validating when
-	persisting the objects is built into FLOW3, so this will be expected in
-	Extbase in the medium term.
+    Certainly it would be helpful if the validation is also be done
+    during the persisting of the objects to the database. At the moment it
+    is not done since the data is stored in the database after sending the
+    answer back to the browser. Therefore the user could not be informed in
+    case of validating errors. In the meantime a second validating when
+    persisting the objects is built into FLOW3, so this will be expected in
+    Extbase in the medium term.
 
 When an error occurs during validation, the method
-:code:`errorAction()` of the current controller is
+`errorAction()` of the current controller is
 called. The provided default ``errorAction()`` redirects the user
 to the last used form when possible, in order to give him a chance to
 correct the errors.
 
 .. tip::
 
-	You may ask how the :code:`errorAction()` knows
-	which form was the last displayed one. This information is created by
-	the ``form`` ViewHelper. He adds automaticly the property
-	``__referrer`` to every generated form, which contains
-	information about the current extension, controller and action
-	combination. This data can be used by the
-	:code:`errorAction()` to display the erroneous form
-	again.
+    You may ask how the `errorAction()` knows
+    which form was the last displayed one. This information is created by
+    the ``form`` ViewHelper. He adds automaticly the property
+    ``__referrer`` to every generated form, which contains
+    information about the current extension, controller and action
+    combination. This data can be used by the
+    `errorAction()` to display the erroneous form
+    again.
 
 Registering validators
 -------------------------------------------------
@@ -174,18 +174,18 @@ available. With it we can specify which validator is to be used for
 checking the annotated property. Let us take a look at this using a part
 of the domain model ``Post`` of the blog example::
 
-	class Tx_BlogExample_Domain_Model_Post extends Tx_Extbase_DomainObject_AbstractEntity {
-		/**
-		 * @var string
-		 * @validate StringLength(minimum=3, maximum=50)
-		 */
-		protected $title;
+    class Tx_BlogExample_Domain_Model_Post extends Tx_Extbase_DomainObject_AbstractEntity {
+        /**
+         * @var string
+         * @validate StringLength(minimum=3, maximum=50)
+         */
+        protected $title;
 
-		/**
-		 * @var string
-		 */
-		protected $content;
-	}
+        /**
+         * @var string
+         */
+        protected $content;
+    }
 
 With the line ``@validate StringLength(minimum=3, 
 maximum=50)`` the validator for the property ``$title`` is
@@ -205,18 +205,18 @@ When you have created your own validator to check the invariants
 you can use it in the ``@validate`` annotation using the full
 class name, like shown in the following example::
 
-	class Tx_BlogExample_Domain_Model_Post extends Tx_Extbase_DomainObject_AbstractEntity {
-		/**
-		 * @var string
-		 * @validate Tx_BlogExample_Domain_Validator_TitleValidator
-		 */
-		protected $title;
+    class Tx_BlogExample_Domain_Model_Post extends Tx_Extbase_DomainObject_AbstractEntity {
+        /**
+         * @var string
+         * @validate Tx_BlogExample_Domain_Validator_TitleValidator
+         */
+        protected $title;
 
-		/**
-		 * @var string
-		 */
-		protected $content;
-	}
+        /**
+         * @var string
+         */
+        protected $content;
+    }
 
 Here we validate the property ``$title`` with the
 :class:`Tx_BlogExample_Domain_Validator_TitleValidator`.
@@ -268,15 +268,15 @@ object is of the type ``user`` - after all the validator can be
 called with any object and has to return ``false`` in such
 case::
 
-	class Tx_ExtbaseExample_Domain_Validator_UserValidator extends Tx_Extbase_Validation_Validator_AbstractValidator {
-		public function isValid($user) {
-			if (! $user instanceof Tx_ExtbaseExample_Domain_Model_User) {
-				$this->addError('The given Object is not a User.', 1262341470);
-				return FALSE;
-			}
-			return TRUE;
-		}
-	}
+    class Tx_ExtbaseExample_Domain_Validator_UserValidator extends Tx_Extbase_Validation_Validator_AbstractValidator {
+        public function isValid($user) {
+            if (! $user instanceof Tx_ExtbaseExample_Domain_Model_User) {
+                $this->addError('The given Object is not a User.', 1262341470);
+                return FALSE;
+            }
+            return TRUE;
+        }
+    }
 
 So, if ``$user`` is not an instance of the user object an
 error message is directly created with ``addError()``. The
@@ -285,29 +285,29 @@ validator does not validate the object any further but returns
 
 .. tip::
 
-	The method ``addError()`` gets two parameters - the
-	first is an error message string while the second is an error number.
-	The Extbase developers always uses the current UNIX timestamp when
-	calling ``addError()``. By this it is secured that the
-	validation errors can be unique identified.
+    The method ``addError()`` gets two parameters - the
+    first is an error message string while the second is an error number.
+    The Extbase developers always uses the current UNIX timestamp when
+    calling ``addError()``. By this it is secured that the
+    validation errors can be unique identified.
 
 Now we have created the foundation of our validator and can start
 with the proper implementation - the check for equality of the
 passwords. This is made quickly::
 
-	class Tx_ExtbaseExample_Domain_Validator_UserValidator extends Tx_Extbase_Validation_Validator_AbstractValidator {
-		public function isValid($user) {
-			if (! $user instanceof Tx_ExtbaseExample_Domain_Model_User) {
-				$this->addError('The given Object is not a User.', 1262341470);
-				return FALSE;
-			}
-			if ($user->getPassword() !== $user->getPasswordConfirmation()) {
-				$this->addError('The passwords do not match.', 1262341707);
-				return FALSE;
-			}
-			return TRUE;
-		}
-	}
+    class Tx_ExtbaseExample_Domain_Validator_UserValidator extends Tx_Extbase_Validation_Validator_AbstractValidator {
+        public function isValid($user) {
+            if (! $user instanceof Tx_ExtbaseExample_Domain_Model_User) {
+                $this->addError('The given Object is not a User.', 1262341470);
+                return FALSE;
+            }
+            if ($user->getPassword() !== $user->getPasswordConfirmation()) {
+                $this->addError('The passwords do not match.', 1262341707);
+                return FALSE;
+            }
+            return TRUE;
+        }
+    }
 
 Because we have access to the complete object the checking
 for equality of ``$password`` and
@@ -337,15 +337,15 @@ controller action. It has the format ``@validate
 *[variablename] [validators]*``, in the example
 below it is ``$pageName`` :class:`Tx_MyExtension_Domain_Validator_PagenameValidator`::
 
-	/**
-	 * Creates a new page with a given name.
-	 *
-	 * @param string $pageName THe name of the page which should be created.
-	 * @validate $pageName Tx_MyExtension_Domain_Validator_PageNameValidator
-	 */
-	public function createPageAction($pageName) {
-		...
-	}
+    /**
+     * Creates a new page with a given name.
+     *
+     * @param string $pageName THe name of the page which should be created.
+     * @validate $pageName Tx_MyExtension_Domain_Validator_PageNameValidator
+     */
+    public function createPageAction($pageName) {
+        ...
+    }
 
 Here the parameter ``$pageName`` is checked with an own
 validator.
@@ -371,16 +371,16 @@ called:
 Lets have a look at the interaction once more with an
 example::
 
-	/**
-	 * Creates a website user for the given page name.
-	 *
-	 * @param string $pageName The name of the page where the user should be created.
-	 * @param Tx_ExtbaseExample_Domain_Model_User $user The user which should be created.
-	 * @validate $user Tx_BlogExample_Domain_Validator_CustomUserValidator
-	 */
-	public function createUserAction($pageName, Tx_ExtbaseExample_Domain_Model_User $user) {
-		...
-	}
+    /**
+     * Creates a website user for the given page name.
+     *
+     * @param string $pageName The name of the page where the user should be created.
+     * @param Tx_ExtbaseExample_Domain_Model_User $user The user which should be created.
+     * @validate $user Tx_BlogExample_Domain_Validator_CustomUserValidator
+     */
+    public function createUserAction($pageName, Tx_ExtbaseExample_Domain_Model_User $user) {
+        ...
+    }
 
 Here the following things are validated: ``$pageName``
 must be a *string*. The data type of the
@@ -412,25 +412,25 @@ validation error. Two actions are involved at editing the blog: The
 
 .. tip::
 
-	If you want to implement edit forms for the domain objects of your
-	extension you should implement it according to the schema displayed
-	here.
+    If you want to implement edit forms for the domain objects of your
+    extension you should implement it according to the schema displayed
+    here.
 
 The ``editAction`` for the blog looks like this::
 
-	public function editAction(Tx_BlogExample_Domain_Model_Blog $blog) {
-		$this->view->assign('blog', $blog);
-	}
+    public function editAction(Tx_BlogExample_Domain_Model_Blog $blog) {
+        $this->view->assign('blog', $blog);
+    }
 
 The blog object that we want to edit is passed and given to the
 view. The Fluid template than looks like this (slightly shortened and
 reduced to the important)::
 
-	<f:form name="blog" object="{blog}" action="update">
-		<f:form.textbox property="title" />
-		<f:form.textbox property="description" />
-		<f:form.submit />
-	</f:form>
+    <f:form name="blog" object="{blog}" action="update">
+        <f:form.textbox property="title" />
+        <f:form.textbox property="description" />
+        <f:form.submit />
+    </f:form>
 
 Note that the ``blog`` object to be edited is bound to the
 form with ``object="{blog}"``. With this you can reference a
@@ -444,9 +444,9 @@ as parameter.
 
 ::
 
-	public function updateAction((Tx_BlogExample_Domain_Model_Blog $blog) {
-		$this->blogRepository->update($blog);
-	}
+    public function updateAction((Tx_BlogExample_Domain_Model_Blog $blog) {
+        $this->blogRepository->update($blog);
+    }
 
 <constraintdef>
 So the name of the argument is ``$blog`` because the form
@@ -456,12 +456,12 @@ be persisted with its changes.
 Now have a look what happens when the user inserts erroneous data
 in the form. In this case an error occurs when validating the
 ``$blog`` arguments. Therefore instead of the
-:code:`updateAction`, the
-:code:`errorAction` is called. These action routes the
+`updateAction`, the
+`errorAction` is called. These action routes the
 request with ``forward()`` to the last used action because in
 case of an error the form should be displayed again. Additional an error
 message is generated and given to the controller. Ergo: In case of a
-validation error the :code:`editAction` is displayed
+validation error the `editAction` is displayed
 again.
 
 As we want to display the erroneous object again it is important
@@ -476,13 +476,13 @@ validation for the ``editAction``. For this we need the
 annotation ``@dontvalidate ``- the comment block of the
 ``editAction`` must be changed like this::
 
-	/**
-	 * @param Tx_BlogExample_Domain_Model_Blog $blog The blog object
-	 * @dontvalidate $blog
-	 */
-	public function editAction(Tx_BlogExample_Domain_Model_Blog $blog) {
-		$this->view->assign('blog', $blog);
-	}
+    /**
+     * @param Tx_BlogExample_Domain_Model_Blog $blog The blog object
+     * @dontvalidate $blog
+     */
+    public function editAction(Tx_BlogExample_Domain_Model_Blog $blog) {
+        $this->view->assign('blog', $blog);
+    }
 
 Now the ``blog`` object is not validated in the
 ``editAction``. So also a non valid ``blog`` object is
@@ -490,9 +490,9 @@ displayed correct.
 
 .. tip::
 
-	If Extbase thows the exception
-	Tx_Extbase_MVC_Exception_InfiniteLoop it signs that the
-	``@dontvalidate`` annotation is missing.
+    If Extbase thows the exception
+    Tx_Extbase_MVC_Exception_InfiniteLoop it signs that the
+    ``@dontvalidate`` annotation is missing.
 
 Fluid automatically adds the CSS class ``f3-form-error``
 to all erroneous fields - so you can frame them in red for example using
@@ -507,53 +507,53 @@ Case study: Create an object
 In the last section you have seen how to edit a blog object with a
 form. Now we will show you how to create a new blog object with a form.
 Also for creating a blog object two actions are involved. The
-:code:`newAction` shows a form for creating an object and
-the :code:`createAction` finally stores the
+`newAction` shows a form for creating an object and
+the `createAction` finally stores the
 object.
 
 The only difference to the editing of an object is that the
-:code:`newAction` is not always given an argument: when
+`newAction` is not always given an argument: when
 first displaying the form it is logical that there is no object available
 to be displayed. Therefore the argument must be marked as optional.
 
 Here you will see all that we need. At first the controller
 code::
 
-	/**
-	 * This action shows the 'new' form for the blog.
-	 *
-	 * @param Tx_BlogExample_Domain_Model_Blog $newBlog The optional default values
-	 * @dontvalidate $newBlog
-	 */
-	public function newAction(Tx_BlogExample_Domain_Model_Blog $newBlog = NULL) {
-		$this->view->assign('newBlog', $newBlog);
-	}
+    /**
+     * This action shows the 'new' form for the blog.
+     *
+     * @param Tx_BlogExample_Domain_Model_Blog $newBlog The optional default values
+     * @dontvalidate $newBlog
+     */
+    public function newAction(Tx_BlogExample_Domain_Model_Blog $newBlog = NULL) {
+        $this->view->assign('newBlog', $newBlog);
+    }
 
-	/**
-	 * This action creates the blog and stores it.
-	 *
-	 * @param Tx_BlogExample_Domain_Model_Blog $newBlog
-	 */
-	public function createAction(Tx_BlogExample_Domain_Model_Blog $newBlog) {
-		$this->blogRepository->add($newBlog);
-	}
+    /**
+     * This action creates the blog and stores it.
+     *
+     * @param Tx_BlogExample_Domain_Model_Blog $newBlog
+     */
+    public function createAction(Tx_BlogExample_Domain_Model_Blog $newBlog) {
+        $this->blogRepository->add($newBlog);
+    }
 
-The Fluid template for the :code:`newAction` looks
+The Fluid template for the `newAction` looks
 like this (in short form)::
 
-	<f:flashMessages />
-	<f:form name="newBlog" object="{newBlog}" action="create">
-		<f:form.textbox property="title" />
-		<f:form.textbox property="description" />
-		<f:form.submit />
-	</f:form>
+    <f:flashMessages />
+    <f:form name="newBlog" object="{newBlog}" action="create">
+        <f:form.textbox property="title" />
+        <f:form.textbox property="description" />
+        <f:form.submit />
+    </f:form>
 
 What is the summary of what we have we done? Again it is important
-that the :code:`newAction` and the
-:code:`createAction` have the same argument name. This
+that the `newAction` and the
+`createAction` have the same argument name. This
 has also to conform with the name of the Fluid template
 (``newBlog`` in the example). Also the parameter for the
-:code:`newAction` must be marked as optional and the
+`newAction` must be marked as optional and the
 validation of the parameter must be suppressed with
 ``@dontvalidate``. Finally you can output validation errors in
 the template using the ``flashMessages`` ViewHelper when saving
@@ -564,10 +564,10 @@ displaying, editing respectively creating of domain objects in the
 frontend.
 
 .. figure:: /Images/9-CrosscuttingConcerns/figure-9-2.png
-	:align: center
+    :align: center
 
-	Figure 9-2: Data flow of the form display and saving. When a validating
-	error occurs it is displayed again.
+    Figure 9-2: Data flow of the form display and saving. When a validating
+    error occurs it is displayed again.
 
 Mapping arguments
 -------------------------------------------------
@@ -591,17 +591,17 @@ our case ``title`` and ``description``.
 
 The Fluid form looks like this (shortened to the essential)::
 
-	<f:form method="post" action="update" name="blog" object="{blog}">
-		<f:form.textbox property="title" />
-		<f:form.textbox property="description" />
-	</f:form>
+    <f:form method="post" action="update" name="blog" object="{blog}">
+        <f:form.textbox property="title" />
+        <f:form.textbox property="description" />
+    </f:form>
 
 If the form is submitted the data will be sent in the following
 manner to the server::
 
-	tx_blogexample_pi1[blog][__identity] = 5
-	tx_blogexample_pi1[blog][title] = My title
-	tx_blogexample_pi1[blog][description] = Description
+    tx_blogexample_pi1[blog][__identity] = 5
+    tx_blogexample_pi1[blog][title] = My title
+    tx_blogexample_pi1[blog][description] = Description
 
 First of all the data is tagged with a prefix that contains the name
 of the extension and the plugin (``tx_blogexample_pi1``). This
@@ -625,10 +625,10 @@ knows the object identity and can go on work with it.
 
 .. tip::
 
-	When you take a look at what is transferred to the server by the
-	new action of the blog example, you will find that no identity
-	properties are transferred - in this case a new object is created as
-	desired.
+    When you take a look at what is transferred to the server by the
+    new action of the blog example, you will find that no identity
+    properties are transferred - in this case a new object is created as
+    desired.
 
 In the blog example from above the __identity property is available,
 therefore the object with the corresponding UID is fetched from the
@@ -640,9 +640,9 @@ object are saved automatically. <remark>!!!Sentence not
 clear</remark>
 
 .. figure:: /Images/9-CrosscuttingConcerns/figure-9-3.png
-	:align: center
+    :align: center
 
-	Figure 9-3: The internal control flow of the property mapper.
+    Figure 9-3: The internal control flow of the property mapper.
 
 In our case not only the ``__identity`` property is sent,
 but also a new ``title`` and ``description`` for our
@@ -659,29 +659,29 @@ replace the existing persistent ``blog`` object with our changed
 ``blog`` object. For this the repository offers a method
 update()::
 
-	$this->blogRepository->update($blog);
+    $this->blogRepository->update($blog);
 
 With this the changed object will be made into the persistent
 object: The changes are stored permanent now.
 
 .. sidebar:: Copies of objects
 
-	Why a copy of an object is created when it is to be changed? Lets
-	have assume that the persistent object would be directly changed. In
-	this case an empty controller would be updating persistent
-	objects::
+    Why a copy of an object is created when it is to be changed? Lets
+    have assume that the persistent object would be directly changed. In
+    this case an empty controller would be updating persistent
+    objects::
 
-		public function updateAction(Tx_BlogExample_Domain_Model_Blog $blog) {
-			// object will be automaticly persisted
-		}
+        public function updateAction(Tx_BlogExample_Domain_Model_Blog $blog) {
+            // object will be automaticly persisted
+        }
 
-	At first this is very in transparent and difficult to understand.
-	Besides of that, this procedure implies a big safety issue: When the
-	original object is changed it would be impossible to cancel the
-	persisting of the changes. For this reason a copy of the object is
-	returned for changed objects, so the developer of the extension has to
-	decide explicit whether or not the changes are to be made
-	persistent.
+    At first this is very in transparent and difficult to understand.
+    Besides of that, this procedure implies a big safety issue: When the
+    original object is changed it would be impossible to cancel the
+    persisting of the changes. For this reason a copy of the object is
+    returned for changed objects, so the developer of the extension has to
+    decide explicit whether or not the changes are to be made
+    persistent.
 
 We want to assume a refinement of the argument mapping: When a link
 to an action is generated and the link contains an object as parameter the
@@ -689,7 +689,7 @@ identity of the object is transferred automatically. In the following
 example the UID is transferred instead of the ``blog``
 object::
 
-	<f:link.action action='show' arguments='{blog: blog}'>Show Blog</f:link.action>
+    <f:link.action action='show' arguments='{blog: blog}'>Show Blog</f:link.action>
 
 The generated URL contains the identity of the blog object:
 ``tx_blogexample_pi1[blog]=47``. That is a short form of


### PR DESCRIPTION
* Streamline inline code highlighting to use single back tics instead of
  :code: and single back ticks, as code is the default role
* Also use spaces instead of tabs in those files, to follow PSR2