### PR TITLE
Feature/update b extbase reference

### DIFF
--- a/Documentation/6-Persistence/2-configure-the-backends-inputforms.rst
+++ b/Documentation/6-Persistence/2-configure-the-backends-inputforms.rst
@@ -827,6 +827,8 @@ newly created object, reaccessing an existing object and updating the properties
 of an existing object. When creating a new object Extbase determines the
 destination pages in the following rule hierarchy:
 
+.. _procedure_to_fetch_objects:
+
 <procedure>
 
 

--- a/Documentation/6-Persistence/3-implement-individual-database-queries.rst
+++ b/Documentation/6-Persistence/3-implement-individual-database-queries.rst
@@ -1,8 +1,9 @@
 .. include:: ../Includes.txt
 
+.. _individual_database_queries:
+
 Individual Database Queries
 ================================================
-
 
 The previous descriptions about generic methods of queries to a Repository are
 sufficient for simple use-cases. However, there are many cases where they are
@@ -26,10 +27,10 @@ implement.
 
 .. note::
 
-	You may start developing your application using the first method and then,
-	seeing your application growing, veering to the second method. Luckily, all
-	the changes are encapsulated in the Repository and you therefore don't have
-	to change any code out of the Persistence Backend.
+    You may start developing your application using the first method and then,
+    seeing your application growing, veering to the second method. Luckily, all
+    the changes are encapsulated in the Repository and you therefore don't have
+    to change any code out of the Persistence Backend.
 
 
 You can use Extbase's *Query*-object for implementing individual queries by
@@ -41,8 +42,6 @@ database backend. Those information contain:
 * (Optional) Parameters which configure a section of the result set by a *limit* or an *offset*.
 * (Optional) Parameters concerning the *Orderings* of the result set.
 
-
-
 Within a Repository you can create a Query object by using the command
 ``$this->createQuery()``. The Query object is already customized to the class
 which is managed by the Repository. Thus, the result set only consists of
@@ -53,20 +52,20 @@ objects of that class, i.e. it consists of Offer objects within the
 objects (or a via limit and offset customized section of it). For example, the
 generic method ``findAll()`` looks as follows::
 
-	public function findAll() {
-		return $this->createQuery()->execute();
-	}
+    public function findAll() {
+        return $this->createQuery()->execute();
+    }
 
 In this simple first use-case we don't any constraining parameter to the Query
 object. However, we have to define such a parameter to implement the first
 specified request "Find all the offers for a certain region". Thus, the
 corresponding method looks as follows::
 
-	public function findInRegion(Tx_SjrOffers_Domain_Model_Region $region) {
-		$query = $this->createQuery();
-		$query->matching($query->contains('regions', $region));
-		return $query->execute();
-	}
+    public function findInRegion(Tx_SjrOffers_Domain_Model_Region $region) {
+        $query = $this->createQuery();
+        $query->matching($query->contains('regions', $region));
+        return $query->execute();
+    }
 
 Using the method ``matching()`` we give the Query the following condition: The
 property *regions* of the object *Offer* (which is managed by the Repository)
@@ -79,14 +78,14 @@ and another operand. The latter mentioned operations connect two conditions to
 one condition by the rules of Boolean Algebra and may negate a result
 respectively. Following Comparing operations are acceptable::
 
-	equals($propertyName, $operand, $caseSensitive = TRUE)
-	in($propertyName, $operand)
-	contains($propertyName, $operand)
-	like($propertyName, $operand)
-	lessThan($propertyName, $operand)
-	lessThanOrEqual($propertyName, $operand)
-	greaterThan($propertyName, $operand)
-	greaterThanOrEqual($propertyName, $operand)
+    equals($propertyName, $operand, $caseSensitive = TRUE)
+    in($propertyName, $operand)
+    contains($propertyName, $operand)
+    like($propertyName, $operand)
+    lessThan($propertyName, $operand)
+    lessThanOrEqual($propertyName, $operand)
+    greaterThan($propertyName, $operand)
+    greaterThanOrEqual($propertyName, $operand)
 
 The method ``equals()`` executes a simple comparison between the property's
 value and the operand which may be a simple PHP data type or a Domain object.
@@ -100,23 +99,22 @@ a multi-valued operand (``$organizations``).
 
 ::
 
-	public function findOfferedBy(array $organizations) {
-		$query = $this->createQuery();
-		$query->matching($query->in('organization', $organizations));
-		return $query->execute();
-	}
-
+    public function findOfferedBy(array $organizations) {
+        $query = $this->createQuery();
+        $query->matching($query->in('organization', $organizations));
+        return $query->execute();
+    }
 
 .. note::
 
-	The methods ``in()`` and ``contains()`` were introduced in Extbase version
-	1.1. If you pass an empty multi-valued property value or an empty
-	multi-valued operand (e.g. an empty Array) to them you always get a *false*
-	as return value for the test. Thus you have to prove if the operand
-	``$organizations`` of the method call ``$query->in('organization',
-	$organizations)`` contains sane values or if it is just an empty Array. This
-	is dependent on your domain logic. In the last example the method
-	``findOfferedBy()`` would return an empty set of values.
+    The methods ``in()`` and ``contains()`` were introduced in Extbase version
+    1.1. If you pass an empty multi-valued property value or an empty
+    multi-valued operand (e.g. an empty Array) to them you always get a *false*
+    as return value for the test. Thus you have to prove if the operand
+    ``$organizations`` of the method call ``$query->in('organization',
+    $organizations)`` contains sane values or if it is just an empty Array. This
+    is dependent on your domain logic. In the last example the method
+    ``findOfferedBy()`` would return an empty set of values.
 
 
 It's possible to use comparison operators that are reaching deep into the tree
@@ -124,9 +122,9 @@ of object hierarchy. Let's assume you want to filter the organizations whether
 they have offers for youngsters older than 16. You may define the request in the
 ``OrganizationRepository`` as follows::
 
-	$query->lessThanOrEqual('offers.ageRange.minimalValue', 16)
+    $query->lessThanOrEqual('offers.ageRange.minimalValue', 16)
 
-Extbase	solves the path ``offers.ageRange.minimalValue`` by seeking every
+Extbase solves the path ``offers.ageRange.minimalValue`` by seeking every
 organization which has offers whose age values have a minimum which is less or
 equal 16. Assuming that a Relational Database System is used in the Persistence
 Backend, this is internally solved by a so-called *INNER JOIN*. All relational
@@ -134,21 +132,21 @@ types (1:1, 1:n, m:n) and all comparison operators are covered by this feature.
 
 .. note::
 
-	The path notation was introduced in Extbase 1.1 and is derived from the
-	*Object-Accessor* notation of Fluid (see Ch. 8). In Fluid you may access
-	object properties with the notation ``{organization.administrator.name}``.
-	However, Fluid does not support the notation
-	``{organization.offers.categories.title}`` whereas
-	``$query->equals('offers.categories.title', 'foo')`` is possible die to the
-	limitation in Fluid that the access of properties is not possible in a
-	"concatenated way".
+    The path notation was introduced in Extbase 1.1 and is derived from the
+    *Object-Accessor* notation of Fluid (see Ch. 8). In Fluid you may access
+    object properties with the notation ``{organization.administrator.name}``.
+    However, Fluid does not support the notation
+    ``{organization.offers.categories.title}`` whereas
+    ``$query->equals('offers.categories.title', 'foo')`` is possible die to the
+    limitation in Fluid that the access of properties is not possible in a
+    "concatenated way".
 
 Besides of the comparison operators the ``Query`` object supports Boolean
 Operators like::
 
-	logicalAnd($constraint1, $constraint2)
-	logicalOr($constraint1, $constraint2)
-	logicalNot($constraint)
+    logicalAnd($constraint1, $constraint2)
+    logicalOr($constraint1, $constraint2)
+    logicalNot($constraint)
 
 The methods above return a ``Constraint`` object. The resulting ``Constraint``
 object of ``logicalAnd()`` is true if both given params ``$constraint1`` and
@@ -159,16 +157,16 @@ accept an Array of constraints. Last but not least, the function
 gets *false* and *false* gets *true*. Given this information, you can create
 complex queries like::
 
-	public function findMatchingOrganizationAndRegion(Tx_SjrOffers_Domain_Model_Organization $organization, Tx_SjrOffers_Domain_Model_Region $region) {
-		$query = $this->createQuery();
-		$query->matching(
-			$query->logicalAnd(
-				$query->equals('organization', $organization),
-				$query->contains('regions', $region)
-			)
-		)
-		return $query->execute();
-	}
+    public function findMatchingOrganizationAndRegion(Tx_SjrOffers_Domain_Model_Organization $organization, Tx_SjrOffers_Domain_Model_Region $region) {
+        $query = $this->createQuery();
+        $query->matching(
+            $query->logicalAnd(
+                $query->equals('organization', $organization),
+                $query->contains('regions', $region)
+            )
+        )
+        return $query->execute();
+    }
 
 The method ``findMatchingOrganizationAndRegion()`` returns those offers that
 match both the given organization and the given region.
@@ -183,41 +181,41 @@ In addition to the restrictions for the needs of the user there comes the reques
 to show the current offers. That denotes that their end date at most are one week ago.
 In the method ``findDemanded()`` of the ``offerRepository`` the request is implemented::
 
-	public function findDemanded(Tx_SjrOffers_Domain_Model_Demand $demand) {
-		$query = $this->createQuery();
-		$constraints = array();
-		if ($demand->getRegion() !== NULL) {
-			$constraints[] = $query->contains('regions', '$demand->getRegion());
-		}
-		if ($demand->getCategory() !== NULL) {
-			$constraints[] = $query->contains('categories', $demand->getCategory());
-		}
-		if ($demand->getOrganization() !== NULL) {
-			$constraints[] = $query->contains('organization', $demand->getOrganization());
-		}
-		if (is_string($demand->getSearchWord()) && strlen($demand->getSearchWord()) > 0) {
-			$constraints[] = $query->like($propertyName, '%' . $demand->getSearchWord . '%');
-		}
-		if ($demand->getAge() !== NULL) {
-			$constraints[] = $query->logicalAnd(
-				$query->logicalOr(
-					$query->equals('ageRange.minimumValue', NULL),
-					$query->lessThanOrEqual('ageRange.minimumValue', $demand->getAge())
-				),
-				$query->logicalOr(
-					$query->equals('ageRange.maximumValue', NULL),
-					$query->greaterThanOrEqual('ageRange.maximumValue', $demand->getAge())
-				),
-			);
-		}
-		$constraints[] = $query->logicalOr(
-			$query->equals('dateRange.minimumValue', NULL),
-			$query->equals('dateRange.minimumValue', 0),
-			$query->greaterThan('dateRange.maximumValue', (time() - 60*60*24*7))
-		);
-		$query->matching($query->logicalAnd($constraints));
-		return $query->execute();
-	}
+    public function findDemanded(Tx_SjrOffers_Domain_Model_Demand $demand) {
+        $query = $this->createQuery();
+        $constraints = array();
+        if ($demand->getRegion() !== NULL) {
+            $constraints[] = $query->contains('regions', '$demand->getRegion());
+        }
+        if ($demand->getCategory() !== NULL) {
+            $constraints[] = $query->contains('categories', $demand->getCategory());
+        }
+        if ($demand->getOrganization() !== NULL) {
+            $constraints[] = $query->contains('organization', $demand->getOrganization());
+        }
+        if (is_string($demand->getSearchWord()) && strlen($demand->getSearchWord()) > 0) {
+            $constraints[] = $query->like($propertyName, '%' . $demand->getSearchWord . '%');
+        }
+        if ($demand->getAge() !== NULL) {
+            $constraints[] = $query->logicalAnd(
+                $query->logicalOr(
+                    $query->equals('ageRange.minimumValue', NULL),
+                    $query->lessThanOrEqual('ageRange.minimumValue', $demand->getAge())
+                ),
+                $query->logicalOr(
+                    $query->equals('ageRange.maximumValue', NULL),
+                    $query->greaterThanOrEqual('ageRange.maximumValue', $demand->getAge())
+                ),
+            );
+        }
+        $constraints[] = $query->logicalOr(
+            $query->equals('dateRange.minimumValue', NULL),
+            $query->equals('dateRange.minimumValue', 0),
+            $query->greaterThan('dateRange.maximumValue', (time() - 60*60*24*7))
+        );
+        $query->matching($query->logicalAnd($constraints));
+        return $query->execute();
+    }
 
 The ``Demand`` object is passed as argument. In the first lien the ``Query`` object is created.
 All single constraint terms are collected in the array ``$constraints`` and finally brought
@@ -229,16 +227,16 @@ the offers without given minimum or maximum age.
 
 ::
 
-	$constraints[] = $query->logicalAnd(
-		$query->logicalOr(
-			$query->equals('ageRange.minimumValue', NULL),
-			$query->lessThanOrEqual('ageRange.minimumValue', $demand->getAge())
-		),
-		$query->logicalOr(
-			$query->equals('ageRange.maximumValue', NULL),
-			$query->greaterThanOrEqual('ageRange.maximumValue', $demand->getAge())
-		),
-	);
+    $constraints[] = $query->logicalAnd(
+        $query->logicalOr(
+            $query->equals('ageRange.minimumValue', NULL),
+            $query->lessThanOrEqual('ageRange.minimumValue', $demand->getAge())
+        ),
+        $query->logicalOr(
+            $query->equals('ageRange.maximumValue', NULL),
+            $query->greaterThanOrEqual('ageRange.maximumValue', $demand->getAge())
+        ),
+    );
 
 This requirement is fulfilled by allowing a not set age (``NULL``) and concatenate this condition
 with ``logicalOr()`` with the condition ``lessThanOrEqual()`` and accordingly ``greaterThenOrEqual()``.
@@ -250,12 +248,12 @@ There are two constants fo the search order: ``Tx_Extbase_Persistence_QueryInter
 for an ascending order and ``Tx_Extbase_Persistence_QueryInterface:ORDER_DESCENDING`` for a descending
 order. A complete sample for specifying a sort order looks like this::
 
-	$query->setOrderings(
-		array(
-			'organization.name' => Tx_Extbase_Persistence_QueryInterface::ORDER_ASCENDING,
-			'title' => Tx_Extbase_Persistence_QueryInterface:ORDER_ASCENDING
-		)
-	);
+    $query->setOrderings(
+        array(
+            'organization.name' => Tx_Extbase_Persistence_QueryInterface::ORDER_ASCENDING,
+            'title' => Tx_Extbase_Persistence_QueryInterface:ORDER_ASCENDING
+        )
+    );
 
 Multiple orderings are processed in the specified order. In our sample the offers are ordered first
 by the name of the organization and inside the organization by the title of the offers in ascending
@@ -266,8 +264,8 @@ If you need only an extract of the result set, you can lower this with the two p
 and ``Offset``. Assumed you want to get the 10. up to 30. offer from the complete result from the
 repository you can achieve it with the following lines::
 
-	$query->setOffset(10);
-	$query->setLimit(20);
+    $query->setOffset(10);
+    $query->setLimit(20);
 
 Both methods expects an integer value. With the method ``setOffset()`` you set the pointer to the
 object you will start with. With the method ``setLimit()`` you set the count of objects you will get
@@ -325,17 +323,17 @@ look at an object with a single value property.
 
  ::
 
-	array(
-		'identifier' => '<identifier>',
-		'classname' => '<classname>',
-		'properties' => array(
-			'<name>' => array(
-				'type' => '<type>',
-				'multivalue' => FALSE,
-				'value' => <value>
-			), ...
-		)
-	)
+    array(
+        'identifier' => '<identifier>',
+        'classname' => '<classname>',
+        'properties' => array(
+            '<name>' => array(
+                'type' => '<type>',
+                'multivalue' => FALSE,
+                'value' => <value>
+            ), ...
+        )
+    )
 
 The value for ``<identifier>`` in Extbase is always the UID of the data record. Together with the class name
 ``<classname>`` it is due to the uniqueness inside the database. The properties are stored in an own
@@ -353,44 +351,44 @@ value (``'multivalue' => TRUE``).
 
 ::
 
-	array(
-		'identifier' => '<identifier>',
-		'classname' => '<classname>',
-		'properties' => array(
-			'<name>' => array(
-				'type' => '<type>',  // always 'Tx_Extbase_Persistence_ObjectStorage'
-				'multivalue' => TRUE,
-				'value' => array(
-					array(
-						'type' => '<type>',
-						'index' => <index>,
-						'value' => <value>
-					), ...
-				)
-			)
-		)
-	)
+    array(
+        'identifier' => '<identifier>',
+        'classname' => '<classname>',
+        'properties' => array(
+            '<name>' => array(
+                'type' => '<type>',  // always 'Tx_Extbase_Persistence_ObjectStorage'
+                'multivalue' => TRUE,
+                'value' => array(
+                    array(
+                        'type' => '<type>',
+                        'index' => <index>,
+                        'value' => <value>
+                    ), ...
+                )
+            )
+        )
+    )
 
 Has a property a NULL value, so it is stored in the object array like this::
 
-	array(
-		'identifier' => '<identifier>',
-		'classname' => '<classname>',
-		'properties' => array(
-			'<name>' => array(
-				'type' => '<type>',
-				'multivalue' => <boolean>,
-				'value' => NULL
-			), ...
-		)
-	)
+    array(
+        'identifier' => '<identifier>',
+        'classname' => '<classname>',
+        'properties' => array(
+            '<name>' => array(
+                'type' => '<type>',
+                'multivalue' => <boolean>,
+                'value' => NULL
+            ), ...
+        )
+    )
 
 The debug output of the return value look like figure 6-13.
 
 .. figure:: /Images/6-Persistence/figure-6-13.png
-	:align: center
+    :align: center
 
-	Figure 6-13: Debug output of "raw" object data
+    Figure 6-13: Debug output of "raw" object data
 
 Maybe in figure 6-13 you have noticed the empty array (``EMPTY!``) of the properties of the organization.
 In the domain model the property ``organization`` of the offer is annotated with ``@lazy``.
@@ -443,6 +441,6 @@ The call
 
 ::
 
-	$offersInRegion = $query->matching($query->contains('regions', $region))->count();
+    $offersInRegion = $query->matching($query->contains('regions', $region))->count();
 
 thus returns the count of offers of a given region.

--- a/Documentation/6-Persistence/4-use-foreign-data-sources.rst
+++ b/Documentation/6-Persistence/4-use-foreign-data-sources.rst
@@ -1,4 +1,5 @@
 .. include:: ../Includes.txt
+.. _using-foreign-data-sources:
 
 Using Foreign Data Sources
 ================================================

--- a/Documentation/6-Persistence/5-modeling-the-class-hierarchy.rst
+++ b/Documentation/6-Persistence/5-modeling-the-class-hierarchy.rst
@@ -1,6 +1,7 @@
 .. include:: ../Includes.txt
+.. _modeling-the-class-hierarchy:
 
-Modelling the Class Hierarchy
+Modeling the Class Hierarchy
 ================================================
 
 In chapter 5 in "Use inheritance in class hierarchies" we have already used class hierarchies.

--- a/Documentation/9-CrosscuttingConcerns/2-validating-domain-objects.rst
+++ b/Documentation/9-CrosscuttingConcerns/2-validating-domain-objects.rst
@@ -1,4 +1,5 @@
 .. include:: ../Includes.txt
+.. _validating-domain-objects:
 
 Validating domain objects
 =========================

--- a/Documentation/9-CrosscuttingConcerns/2-validating-domain-objects.rst
+++ b/Documentation/9-CrosscuttingConcerns/2-validating-domain-objects.rst
@@ -403,6 +403,7 @@ prevents the processing of the ``@validate`` annotations in the
 domain model and calling the validator class of the domain
 object.
 
+.. _case_study-edit_an_existing_object:
 
 Case study: Edit an existing object
 -----------------------------------

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -48,4 +48,6 @@ use_opensearch       = https://docs.typo3.org/typo3cms/ExtbaseFluidBook
 [intersphinx_mapping]
 
 t3coreapi = https://docs.typo3.org/typo3cms/CoreApiReference/
+t3tsconfig = https://docs.typo3.org/typo3cms/TSconfigReference/
 t3api = http://typo3.org/api/typo3cms/
+extcore = https://docs.typo3.org/typo3cms/extensions/core/latest/

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -45,3 +45,7 @@ project_issues       = https://github.com/TYPO3-Documentation/TYPO3CMS-Book-Extb
 project_repository   = https://github.com/TYPO3-Documentation/TYPO3CMS-Book-ExtbaseFluid.git
 use_opensearch       = https://docs.typo3.org/typo3cms/ExtbaseFluidBook
 
+[intersphinx_mapping]
+
+t3coreapi = https://docs.typo3.org/typo3cms/CoreApiReference/
+t3api = http://typo3.org/api/typo3cms/

--- a/Documentation/b-ExtbaseReference/Index.rst
+++ b/Documentation/b-ExtbaseReference/Index.rst
@@ -1,3 +1,9 @@
+.. Todo: Interfaces are currently not in the inventory of t3api.
+    We should reference them, as soon as they are inside. Xavier already rendered them, but I didn't
+    get the url running for latest.
+
+.. _extbase_reference:
+
 Extbase Reference
 =================
 
@@ -7,24 +13,38 @@ Extbase extensions.
 
 .. note::
 
-	Under http://typo3.org/go/extbasereferencesheet/ you find a useful
-	Cheat Sheet for Extbase and Fluid.
+    Under https://docs.typo3.org/typo3cms/CheatSheets.html you find a useful Cheat Sheet for Extbase
+    and Fluid.
 
-.. _configuration_of_frontend_plugins:
+.. _registration_of_frontend_plugins:
 
 Registration of frontend plugins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In classical TYPO3 extensions the front-end functionality is divided into
-several front-end Plugins. Normally each has a separate code base.
+.. Todo: Add section about backend modules.
+
+.. sidebar:: Why two files?
+
+    You may wonder why you need to edit both, file :file:`ext_localconf.php` and file
+    :file:`ext_tables.php`, to configure a plugin. The reason lays in the architecture of TYPO3:
+    file :file:`ext_localconf.php` is evaluated in the frontend and file :file:`ext_tables.php` in
+    the backend. Therefore, in file :file:`ext_tables.php` we add the entry to the plugin list (for
+    the backend). In addition, the list of controller / action combinations is required at runtime
+    in the frontend - and therefore this must be defined in the file file :file:`ext_localconf.php`.
+
+    For further information, check out :ref:`Extenion configuration files
+    <t3coreapi:extension-configuration-files>`.
+
+In classical TYPO3 extensions the frontend functionality is divided into
+several frontend plugins. Normally each has a separate code base.
 In contrast, there is only one code base in Extbase (a series of controllers and
-Actions). Nevertheless, it should be possible to group controllers and Actions
-to make it possible to have multiple front-end plugins.
+actions). Nevertheless, it is possible to group controllers and actions
+to make it possible to have multiple frontend plugins.
 
 For the definition of a plugin, the files :file:`ext_localconf.php` and :file:`ext_tables.php`
 have to be adjusted.
 
-In :file:`ext_localconf.php` resides the definition of permitted Controller Action
+In :file:`ext_localconf.php` resides the definition of permitted controller action
 Combinations. Also here you have to define which actions should not be cached.
 In :file:`ext_tables.php` there is only the configuration of the plugin selector for the
 backend. Let's have a look at the following two files:
@@ -36,17 +56,17 @@ backend. Let's have a look at the following two files:
         $pluginName
         $controllerActionCombinations,
         $uncachedActions
-    }
+    );
 
-In addition to the extension key and a unique name of the plugin (line 2 and 3)
+In addition to the extension key and a unique name of the plugin (line 2 and 3),
 the allowed combinations of the controller and actions are determined.
 ``$controllerActionCombinations`` is an associative array. The Keys of this array
-are the allowed Controllers, and the values are a comma-separated list of
-allowed actions per Controller. The first action of the first controller is the
+are the allowed controllers, and the values are a comma-separated list of
+allowed actions per controller. The first action of the first controller is the
 default action.
 
 Additionally you need to specify which actions should not be cached. To do this,
-the fourth parameter also is a list of Controller / Action - Combinations in the
+the fourth parameter also is a list of controller action Combinations in the
 same format as above, containing all the non-cached-actions.
 
 :file:`ext_tables.php`::
@@ -57,8 +77,8 @@ same format as above, containing all the non-cached-actions.
         $backendTitle
     );
 
-The extension key and $pluginName must be completely identical to the definition
-in :file:`ext_localconf.php`. $backendTitle defines the displayed name of the plugin in
+The extension key and ``$pluginName`` must be completely identical to the definition
+in :file:`ext_localconf.php`. ``$backendTitle`` defines the displayed name of the plugin in
 the Backend.
 Below there is a complete configuration example for the registration of a
 frontend plugin within the files :file:`ext_localconf.php` and :file:`ext_tables.php`.
@@ -94,127 +114,129 @@ frontend plugin within the files :file:`ext_localconf.php` and :file:`ext_tables
 
 The plugin name is ``Blog``. It is important that in :file:`ext_localconf.php` and
 :file:`ext_tables.php` the name is exactly the same. The default action is the action
-index of the Controller *Blog* since this is the first element defined in the
+``index`` of the controller ``blog`` since this is the first element defined in the
 array and the first action in the list.
+
+All actions which change data must not be cacheable. Above, this is for example
+the ``delete`` action in the ``blog`` controller. In the backend you can see "*A Blog
+Example*" in the list of plugins (see Figure B-1).
+
+.. figure:: /Images/b-ExtbaseReference/figure-b-1.png
+    :align: center
+
+    Figure B-1: In the selection field for frontend plugins, the name which was defined in the
+    file :file:`ext_tables.php` will be displayed
+
+.. _caching_of_actions_and_records:
 
 Caching of actions and records
 ------------------------------
 
-All actions which change data must not be cacheable. Above, this is for example
-the delete action in the blog controller. In the backend now you can see A Blog
-Example in the list of plugins (see Figure B-1).
-
-.. Todo: Add section about backend modules.
-
-.. figure:: /Images/b-ExtbaseReference/figure-b-1.png
-	:align: center
-
-	Figure B-1: In the selection field for frontend plugins, the name which was defined in the
-	file :file:`ext_tables.php` will be displayed
-
-.. sidebar:: Why two files?
-
-	You may wonder why you need to edit both file :file:`ext_localconf.php` and file :file:`ext_tables.php` to
-	configure a plugin. The reason lays in the architecture of TYPO3:
-	file :file:`ext_localconf.php` is evaluated in the frontend and file :file:`ext_tables.php` in the
-	backend. Therefore, in file :file:`ext_tables.php` we add the entry to the plugin list (for
-	the back end). In addition, the list of controller / action combinations is
-	required at runtime in the frontend - and therefore this must be defined in the
-	file file :file:`ext_localconf.php`.
-
-Furthermore, Extbase is clearing the TYPO3 cache automatically for update
-processes. This is called *Automatic cache clearing*. This functionality is
-activated by default. If a domain object is inserted, changed or deleted, then
-the cache of the corresponding page in which the object is located is cleared.
-Additionally the setting of TSConfig ``TCEMAIN.clearCacheCmd`` is evaluated for this
-page.
+Furthermore, Extbase is clearing the TYPO3 cache automatically for update processes. This is called
+*Automatic cache clearing*. This functionality is activated by default. If a domain object is
+inserted, changed or deleted, then the cache of the corresponding page in which the object is
+located is cleared.  Additionally the setting
+of TSConfig :ref:`TCEMAIN.clearCacheCmd <t3tsconfig:pagetcemain-clearcachecmd>` is evaluated for this page.
 
 Figure B-2 is an example that is explained below:
 
 .. figure:: /Images/b-ExtbaseReference/figure-b-2.png
-	:align: center
+    :align: center
 
-	Figure B-2: For the sysfolder in which the data was stored, the setting
-	``TCEMAIN.clearCacheCmd`` defines that the cache of the page *Blog* should be
-	emptied.
+    Figure B-2: For the sysfolder in which the data was stored, the setting
+    :ref:`TCEMAIN.clearCacheCmd <t3tsconfig:pagetcemain-clearcachecmd>` defines that the cache of
+    the page *Blog* should be emptied.
 
-
-The frontend plugin is on the page *Blog* with the ID 11. As a storage folder
-for all the blogs and posts the SysFolder *BLOGS* is configured. Now, if an entry
-is changed, then the cache of the sysFolder *BLOGS* is emptied and also the
-TSConfig configuration ``TCEMAIN.clearCacheCmd`` for the sysFolder is evaluated.
-This contains a comma-separated list of Page IDs, for which the cache should be
-emptied. In this case, when updating a record in the SysFolder *BLOGS* (e.g.
-Blogs, Posts, Comments) automatically the cache of the page *Blog* (with ID 11)
-is cleared, so the changes are immediately visible.
+The frontend plugin is on the page *Blog* with the *11*. As a storage folder for all the Blogs and
+Posts the SysFolder *BLOGS* is configured. If an entry is changed, the cache of the SysFolder
+*BLOGS* is emptied and also the TSConfig configuration
+:ref:`TCEMAIN.clearCacheCmd <t3tsconfig:pagetcemain-clearcachecmd>` for the SysFolder is evaluated.
+This contains a comma-separated list of Page IDs, for which the cache should be emptied. In this
+case, when updating a record in the SysFolder *BLOGS* (e.g.  Blogs, Posts, Comments), the cache of
+the page *Blog* (with ID 11) is cleared automatically, so the changes are immediately visible.
 
 Even if the user enters incorrect data in a form (and this form will be
 displayed again), the cache of the current page is deleted to force a new
 representation of the form.
 
 The automatic cache clearing is enabled by default, you can use TypoScript
-configuration to disable it (see next section).
+configuration to disable it (see :ref:`features.skipDefaultArguments <features-skipDefaultArguments>`).
+
+.. _typoscript_configuration:
 
 TypoScript Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Each Extbase-based extension has some settings which can be modified using
-TypoScript. Many of these settings affect aspects of the internal Configuration
-of Extbase and Fluid. There is also a block ``settings`` in which you can set
-Extension-specific settings, which can be accessed in the Controllers and
-Templates of your extensions.
+Each Extbase based extension has some settings which can be modified using TypoScript. Many of these
+settings affect aspects of the internal Configuration of Extbase and Fluid. There is also a block
+``settings`` in which you can set Extension specific settings, which can be accessed in the
+controllers and Templates of your extensions.
 
 **plugin.tx_[lowercasedextensionname]**
 
 The TypoScript configuration of the extension is always located below this
 TypoScript path. The "lowercased extension name" is the extension key with no
-underscore (_), as for example in blogexample. The configuration is divided into
+underscore (_), as for example in ``blogexample``. The configuration is divided into
 the following sections:
+
+.. _typoscript_configuration-features:
 
 features
 --------
 
 Activate features for Extbase or a specific plugin.
 
+.. _features-skipDefaultArguments:
+
 ``features.skipDefaultArguments``
-	Skip default arguments in URLs. If a link to the default controller or action
-	is created, the parameters are omitted.
-	Default is ``false``.
+    Skip default arguments in URLs. If a link to the default controller or action is created, the
+    parameters are omitted.
+    Default is ``false``.
+
+.. _features-ignoreAllEnableFieldsInBe:
+
+``features.ignoreAllEnableFieldsInBe``
+    Ignore the enable fields in backend.
+    Default is ``false``.
+
+.. _typoscript_configuration-persistence:
 
 persistence
 -----------
 
-Here are settings relevant to the persistence layer of Extbase.
+Settings relevant to the persistence layer of Extbase.
 
 ``persistence.classes``
-	This settings are used with individual classes. That includes in particular the
-	mapping of classes and property names to tables and field names.
+    This settings are used with individual classes. That includes in particular the
+    mapping of classes and property names to tables and field names.
 
 ``persistence.classes.Vendor\MyExt\Domain\Model\Foo.mapping.columns``
-	Here you can configure fields which differ from the regular naming conventions.
-	You use the form ``field_name.mapOnProperty = propertyName``.
+    Configure fields which differ from the regular naming conventions.
+    Use the form ``field_name.mapOnProperty = propertyName``.
 
 ``persistence.classes.Vendor\MyExt\Domain\Model\Foo.mapping.recordType``
-	Here you can specify a string literal, which - if set - should be stored in the
-	type field of the table.
+    Specify a string literal, which - if set - should be stored in the
+    type field of the table.
 
 ``persistence.classes.Vendor\MyExt\Domain\Model\Foo.mapping.tableName``
-	Here you can set a table name which differs from the regular naming conventions.
+    Set a table name which differs from the regular naming conventions.
 
 ``persistence.classes.Vendor\MyExt\Domain\Model\Foo.newRecordStoragePid``
-	Page-ID in which new records of the given class should be saved.
+    Page-ID in which new records of the given class should be saved.
 
 ``persistence.classes.Vendor\MyExt\Domain\Model\Foo.subclasses``
-	List all subclasses of the class given in the form *ClassName = ClassName*.
+    List all subclasses of the class given in the form *ClassName = ClassName*.
 
 ``persistence.enableAutomaticCacheClearing``
-	Enables the automatic cache clearing when changing data sets (see also the
-	section "Configuration of frontend plugins" above in this chapter).
-	Enabled by default.
+    Enables the automatic cache clearing when changing data sets (see also the
+    section ":ref:`caching_of_actions_and_records`" above in this chapter).
+    Default is ``true``.
 
 ``persistence.storagePid``
-	List of Page-IDs, from which all records are read (see the section "Creating the
-	repositories" in Chapter 6).
+    List of Page-IDs, from which all records are read (see the section
+    ":ref:`Procedure to fetch objects <procedure_to_fetch_objects>`" in Chapter 6).
+
+.. _typoscript_configuration-settings:
 
 settings
 --------
@@ -223,37 +245,57 @@ Here reside are all the domain-specific extension settings. This setting are
 available as an array in the controllers in ``$this->settings`` and in any Fluid
 template with ``{settings}``.
 
+.. tip::
+
+    The settings allow you to pass orbitary information to template, even for 3rd party extensions.
+    Just make sure you prefix them with a unique vendor to prevent collisions with further updates
+    of the extensions.
+
+.. _typoscript_configuration-view:
+
 view
 ----
 
 View and template settings.
 
 ``view.layoutRootPath``
-	This can be used to specify the root path for all fluid layouts in this
-	extension. If nothing is specified, the path
-	:file:`extensionName/Resources/Private/Layouts` is used. All layouts that are necessary
-	for this extension should reside in this folder.
+    This can be used to specify the root path for all fluid layouts in this
+    extension. If nothing is specified, the path
+    :file:`extensionName/Resources/Private/Layouts` is used. All layouts that are necessary
+    for this extension should reside in this folder.
 
 ``view.partialRootPath``
-	This can be used to specify the root path for all fluid partials in this
-	extension. If nothing is specified, the path
-	:file:`extensionName/Resources/Private/Partials` is used. All partials that are
-	necessary for this extension should reside in this folder.
+    This can be used to specify the root path for all fluid partials in this
+    extension. If nothing is specified, the path
+    :file:`extensionName/Resources/Private/Partials` is used. All partials that are
+    necessary for this extension should reside in this folder.
 
 ``view.pluginNamespace``
-	This can be used to specify an alternative namespace for the plugin.
-	Use this to shorten the Extbase default plugin namespace or to access
-	arguments from other extensions by setting this option to their namespace.
+    This can be used to specify an alternative namespace for the plugin.
+    Use this to shorten the Extbase default plugin namespace or to access
+    arguments from other extensions by setting this option to their namespace.
 
 ``view.templateRootPath``
-	This can be used to specify the root path for all fluid templates in this
-	extension. If nothing is specified, the path
-	:file:`extensionName/Resources/Private/Templates` is used. All layouts that are necessary
-	for this extension should reside in this folder.
+    This can be used to specify the root path for all fluid templates in this
+    extension. If nothing is specified, the path
+    :file:`extensionName/Resources/Private/Templates` is used. All layouts that are necessary
+    for this extension should reside in this folder.
 
-	There is no fallback to the files that are delivered with an extension!
-	Therefore you need to copy all original templates to this folder before you set
-	this TypoScript setting.
+    There is no fallback to the files that are delivered with an extension!
+    Therefore you need to copy all original templates to this folder before you set
+    this TypoScript setting.
+
+.. Todo: Add feature #66111, multiple paths for fluid.
+
+.. tip::
+
+    Since TYPO3 CMS 7.3, it's possible to use multiple paths. The feature was introduced by
+    `Feature: #66111 - Add TemplateRootPaths support to cObject FLUIDTEMPLATE
+    <https://docs.typo3.org/typo3cms/extensions/core/latest/Changelog/7.3/Feature-66111-AddTemplaterootpathsSupportToCobjectFluidtemplate.html#feature-66111-add-templaterootpaths-support-to-cobject-fluidtemplate>`_.
+    We will update the documentation in the near future to reflect this new possibilities.
+    In the meantime, just check out the documentation for the feature.
+
+.. _typoscript_configuration-local_lang:
 
 _LOCAL_LANG
 -----------
@@ -262,6 +304,8 @@ Under this key you can modify localized strings for this extension.
 If you specify for example ``plugin.tx_blogexample._LOCAL_LANG.default.read_more =
 More>>`` then the standard translation for the key read_more is overwritten by the
 string *More>>*.
+
+.. _class_hierarchy:
 
 Class Hierarchy
 ^^^^^^^^^^^^^^^
@@ -274,18 +318,20 @@ have special requirements that can not be realized with the ActionController,
 you should have a look at the controllers below.
 
 :class:`\\TYPO3\\CMS\\Extbase\\Mvc\\Controller\\ControllerInterface`
-	The basic interface that must be implemented by all controllers.
+    The basic interface that must be implemented by all controllers.
 
 :ref:`t3api:TYPO3\\CMS\\Extbase\\Mvc\\Controller\\AbstractController`
-	Abstract controller with basic functionality.
+    Abstract controller with basic functionality.
 
 :ref:`t3api:TYPO3\\CMS\\Extbase\\Mvc\\Controller\\ActionController`
-	The most widely used controller in Extbase. An overview of its API is given in
-	the following section.
+    The most widely used controller in Extbase. An overview of its API is given in
+    the following section.
 
 :ref:`t3api:TYPO3\\CMS\\Extbase\\Mvc\\Controller\\CommandController`
-	Extend this controller if you want to provide commands to the scheduler or command line
-	interface.
+    Extend this controller if you want to provide commands to the scheduler or command line
+    interface.
+
+.. _class_hierarchy-action_controller_api:
 
 ActionController API
 --------------------
@@ -294,79 +340,84 @@ The action controller is usually the base class for your own controller. Below
 you see the most important properties of the action controller:
 
 ``$actionMethodName``
-	Name of the executed action.
+    Name of the executed action.
 
 ``$argumentMappingResults``
-	Results of the argument mapping. Is used especially in the errorAction.
+    Results of the argument mapping. Is used especially in the errorAction.
 
 ``$defaultViewObjectName``
-	Name of the default view, if no fluid-view or an action-specific view was found.
+    Name of the default view, if no fluid-view or an action-specific view was found.
 
 ``$errorMethodName``
-	Name of the action that is performed when generating the arguments of actions
-	fail. Default is errorAction. In general, it is not sensible to change this.
+    Name of the action that is performed when generating the arguments of actions
+    fail. Default is errorAction. In general, it is not sensible to change this.
 
 ``$request``
-	Request object of type :class:`\\TYPO3\\CMS\\Extbase\\Mvc\\RequestInterface`.
+    Request object of type :class:`\\TYPO3\\CMS\\Extbase\\Mvc\\RequestInterface`.
 
 ``$response``
-	Response object of type :class:`\\TYPO3\\CMS\\Extbase\\Mvc\\ResponseInterface`.
+    Response object of type :class:`\\TYPO3\\CMS\\Extbase\\Mvc\\ResponseInterface`.
 
 ``$settings``
-	Domain-specific extension settings from TypoScript (as array).
+    Domain-specific extension settings from TypoScript (as array).
 
 ``$view``
-	The view used of type :class:`\\TYPO3\\CMS\\Extbase\\Mvc\\View\\ViewInterface`.
+    The view used of type :class:`\\TYPO3\\CMS\\Extbase\\Mvc\\View\\ViewInterface`.
 
 ``$viewObjectNamePattern``
-	If no fluid template is found for the current action, Extbase attempts to find a
-	PHP-View-Class for the action. The naming scheme of the PHP-View-Class can be
-	changed here. By default names are used according to the scheme
-	*@vendor\@extension\View\@controller\@action@format*. All string-parts marked with @
-	are replaced by the corresponding values. If no view class with this name is
-	found, @format is removed from the pattern and again tried to find a view class
-	with that name.
+    If no fluid template is found for the current action, Extbase attempts to find a
+    PHP-View-Class for the action. The naming scheme of the PHP-View-Class can be
+    changed here. By default names are used according to the scheme
+    *@vendor\@extension\View\@controller\@action@format*. All string-parts marked with @
+    are replaced by the corresponding values. If no view class with this name is
+    found, @format is removed from the pattern and again tried to find a view class
+    with that name.
 
-Most important API methods of the action controller
+
+.. _class_hierarchy-most_important_api_methods_of_action_controller:
+
+Most important API methods of action controller
 ---------------------------------------------------
 
 :code:`Action()`
-	Defines an action.
+    Defines an action.
 
 :code:`errorAction()`
-	Standard error action. Needs to be adjusted only in very rare cases. The name of
-	this method is defined by the property $errorMethodName.
+    Standard error action. Needs to be adjusted only in very rare cases. The name of
+    this method is defined by the property $errorMethodName.
 
 :code:`forward($actionName, $controllerName = NULL, $extensionName = NULL, array $arguments = NULL)`
-	Issues an immediate internal forwarding of the request to another controller.
+    Issues an immediate internal forwarding of the request to another controller.
 
 :code:`initializeAction()`
-	Initialization method for all actions. Can be used to e.g. register arguments.
+    Initialization method for all actions. Can be used to e.g. register arguments.
 
 :code:`initialize[actionName]Action()`
-	Action-specific initialization, which is called only before the specific action.
-	Can be used to e.g. register arguments.
+    Action-specific initialization, which is called only before the specific action.
+    Can be used to e.g. register arguments.
 
 :code:`initializeView(\TYPO3\CMS\Extbase\Mvc\View\ViewInterface $ view)`
-	Initialization method to configure and initialize the passed view.
+    Initialization method to configure and initialize the passed view.
 
 :code:`redirect($actionName, $controllerName = NULL, $extensionName = NULL, array $arguments = NULL, $pageUid = NULL, $delay = 0, $statusCode = 303)`
-	External HTTP redirect to another controller (immediately)
+    External HTTP redirect to another controller (immediately)
 
 :code:`redirectToURI($uri, $delay = 0, $statusCode = 303)`
-	Redirect to full URI (immediately)
+    Redirect to full URI (immediately)
 
 :code:`resolveView()`
-	By overriding this method you can build and configure a completely individual
-	view object. This method should return a complete view object. In general,
-	however, it is sufficient to overwrite resolveViewObjectName().
+    By overriding this method you can build and configure a completely individual
+    view object. This method should return a complete view object. In general,
+    however, it is sufficient to overwrite resolveViewObjectName().
 
 :code:`resolveViewObjectName()`
-	Resolves the name of the view object, if no suitable fluid template could be
-	found.
+    Resolves the name of the view object, if no suitable fluid template could be
+    found.
 
 :code:`throwStatus($statusCode, $statusMessage = NULL, $content = NULL)`
-	The specified HTTP status code is sent immediately.
+    The specified HTTP status code is sent immediately.
+
+.. _class_hierarchy-actions:
 
 Actions
 -------
@@ -407,6 +458,8 @@ Default values can, as usual in PHP, just be indicated in the method signature. 
 the default value of the parameter ``$newBlog`` is set to NULL. If an action returns NULL or nothing,
 then automatically ``$this->view->render()`` is called, and thus the view is rendered.
 
+.. _class_hierarchy-define_initialization_code:
+
 Define initialization code
 --------------------------
 
@@ -418,6 +471,8 @@ the registration of arguments, but before calling the appropriate action method 
 generic :code:`initializeAction()`, if it exists, a method named *initialize[ActionName]()* is called.
 Here you can perform action specific initializations (e.g. :code:`initializeShowAction()`).
 Only then the action itself is called.
+
+.. _class_hierarchy-catching_validation_errors_with_error_action:
 
 Catching validation errors with errorAction
 -------------------------------------------
@@ -434,13 +489,13 @@ The domain of the extension is always located below :file:`Classes/Domain`. This
 as follows:
 
 :file:`Model/`
-	Contains the domain model itself.
+    Contains the domain model itself.
 
 :file:`Repository/`
-	Contains the repositories to access the domain model.
+    Contains the repositories to access the domain model.
 
 :file:`Validator/`
-	Contains specific validators for the domain model.
+    Contains specific validators for the domain model.
 
 Domain model
 ------------
@@ -448,11 +503,11 @@ Domain model
 All classes of the domain model must inherit from one of the following two classes:
 
 :class:`\\TYPO3\\CMS\\Extbase\\DomainObject\\AbstractEntity`
-	Is used if the object is an entity, i.e. possesses an identity.
+    Is used if the object is an entity, i.e. possesses an identity.
 
 :class:`\\TYPO3\\CMS\\Extbase\\DomainObject\\AbstractValueObject`
-	Is used if the object is a ValueObject, i.e. if its identity is defined by all of its properties.
-	ValueObjects are immutable.
+    Is used if the object is a ValueObject, i.e. if its identity is defined by all of its properties.
+    ValueObjects are immutable.
 
 Repositories
 ------------
@@ -469,30 +524,30 @@ Public Repository API
 Each repository provides the following public methods:
 
 :code:`add($object)`
-	Adds a new object.
+    Adds a new object.
 
 :code:`findAll()` and :code:`countAll()`
-	returns all domain objects (or the number of them) it is responsible for.
+    returns all domain objects (or the number of them) it is responsible for.
 
 :code:`findByUid($uid)`
-	Returns the domain object with this UID.
+    Returns the domain object with this UID.
 
 :code:`findByProperty($propertyValue)` and :code:`countByProperty($propertyValue)`
-	Magic finder method. Finding all objects (or the number of them) for the property *property* having
-	a value of ``$propertyValue`` and returns them in an array, or the number as an integer value.
+    Magic finder method. Finding all objects (or the number of them) for the property *property* having
+    a value of ``$propertyValue`` and returns them in an array, or the number as an integer value.
 
 :code:`findOneByProperty($propertyValue)`
-	Magic finder method. Finds the first object, for which the given property *property* has the value
-	$propertyValue.
+    Magic finder method. Finds the first object, for which the given property *property* has the value
+    $propertyValue.
 
 :code:`remove($object)` and :code:`removeAll()`
-	Deletes an object (or all objects) in the repository.
+    Deletes an object (or all objects) in the repository.
 
 :code:`replace($existingObject, $newObject)`
-	Replaces an object of the repositories with another.
+    Replaces an object of the repositories with another.
 
 :code:`update($object)`
-	Updates the persisted object.
+    Updates the persisted object.
 
 Custom find methods in repositories
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -521,47 +576,47 @@ object a constraint using ``$query->matching($constraint)``. The following compa
 generating a single condition are available:
 
 :code:`$query->equals($propertyName, $operand, $caseSensitive);`
-	Simple comparison between the value of the property provided by $propertyName and the operand.
-	In the case of strings you can specified additionally, whether the comparison is case-sensitive.
+    Simple comparison between the value of the property provided by $propertyName and the operand.
+    In the case of strings you can specified additionally, whether the comparison is case-sensitive.
 
 :code:`$query->in($propertyName, $operand);`
-	Checks if the value of the property _$propertyName_ is present within the series of values in ``$operand``.
+    Checks if the value of the property _$propertyName_ is present within the series of values in ``$operand``.
 
 :code:`$query->contains($propertyName, $operand);`
-	Checks whether the specified property ``$propertyName`` containing a collection has an element
-	``$operand`` within that collection.
+    Checks whether the specified property ``$propertyName`` containing a collection has an element
+    ``$operand`` within that collection.
 
 :code:`$query->like($propertyName, $operand);`
-	Comparison between the value of the property specified by $propertyName and a string $operand.
-	In this string, the %-character is interpreted as placeholder (similar to * characters in search
-	engines, in reference to the SQL syntax).
+    Comparison between the value of the property specified by $propertyName and a string $operand.
+    In this string, the %-character is interpreted as placeholder (similar to * characters in search
+    engines, in reference to the SQL syntax).
 
 :code:`$query->lessThan($propertyName, $operand);`
-	Checks if the value of the property $propertyName is less than the operand.
+    Checks if the value of the property $propertyName is less than the operand.
 
 :code:`$query->lessThanOrEqual($propertyName, $operand);`
-	Checks if the value of the property $propertyName is less than or equal to the operand.
+    Checks if the value of the property $propertyName is less than or equal to the operand.
 
 :code:`$query->greaterThan($propertyName, $operand);`
-	Checks if the value of the property $propertyName is greater than the operand.
+    Checks if the value of the property $propertyName is greater than the operand.
 
 :code:`$query->greaterThanOrEqual($propertyName, $operand);`
-	Checks if the value of the property $propertyName is greater than or equal to the operand.
+    Checks if the value of the property $propertyName is greater than or equal to the operand.
 
 Since 1.1 ``$propertyName`` is not necessarily only a simple property-name but also can be a "property path".
     Example: ``$query->equals('categories.title', 'tools')`` searches for objects having a category titled
     "tools" assigned. If necessary, you can combine multiple conditions with boolean operations.
 
 :code:`$query->logicalAnd($constraint1, $constraint2);`
-	Two conditions are joined with a logical *and*, it gives back the resulting condition. Since Extbase
-	1.1 also an array of conditions is allowed.
+    Two conditions are joined with a logical *and*, it gives back the resulting condition. Since Extbase
+    1.1 also an array of conditions is allowed.
 
 :code:`$query->logicalOr($constraint1, $constraint2);`
-	Two conditions are joined with a logical *or*, it gives back the resulting condition. Since Extbase
-	1.1 also an array of conditions is allowed.
+    Two conditions are joined with a logical *or*, it gives back the resulting condition. Since Extbase
+    1.1 also an array of conditions is allowed.
 
 :code:`$query->logicalNot($constraint);`
-	Returns a condition that inverts the result of the given condition (logical *not*).
+    Returns a condition that inverts the result of the given condition (logical *not*).
 
 In the section "Individual queries," in Chapter 6  you can find a comprehensive example for building queries.
 
@@ -584,15 +639,15 @@ can also write your own validators. Each Validator implements the
 methods:
 
 :code:`getErrors()`
-	Returns any error messages of the last validation.
+    Returns any error messages of the last validation.
 
 :code:`isValid($value)`
-	Checks whether the object that was passed to the validator is valid. If yes,
-	returns true, otherwise false.
+    Checks whether the object that was passed to the validator is valid. If yes,
+    returns true, otherwise false.
 
 :code:`setOptions(array $validationOptions)`
-	Sets specific options for the validator. These options apply to any further call
-	of the method isValid().
+    Sets specific options for the validator. These options apply to any further call
+    of the method isValid().
 
 You can call Validators in your own code with the method
 :code:`createValidator($validatorName, $validatorOptions)` in
@@ -674,17 +729,17 @@ does all the translation. The method can be called like this:
 ``\TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate($key, $extensionName, $arguments=NULL)``
 
 ``$key``
-	The identifier to be translated. If then format *LLL:path:key* is given, then this
-	identifier is used and the parameter $extensionName is ignored. Otherwise, the
-	file :file:`Resources/Private/Language/locallang.xml` from the given extension is loaded
-	and the resulting text for the given key in the current language returned.
+    The identifier to be translated. If then format *LLL:path:key* is given, then this
+    identifier is used and the parameter $extensionName is ignored. Otherwise, the
+    file :file:`Resources/Private/Language/locallang.xml` from the given extension is loaded
+    and the resulting text for the given key in the current language returned.
 
 ``$extensionName``
-	The extension name. It can be fetched from the request.
+    The extension name. It can be fetched from the request.
 
 ``$arguments``
-	Allows you to specify an array of arguments passed to the function vsprintf. Allows you to fill
-	wildcards in localized strings with values.
+    Allows you to specify an array of arguments passed to the function vsprintf. Allows you to fill
+    wildcards in localized strings with values.
 
 In Fluid there is the translate ViewHelper, which works by the same rules. For a
 case study for localization, see Chapter 9.

--- a/Documentation/b-ExtbaseReference/Index.rst
+++ b/Documentation/b-ExtbaseReference/Index.rst
@@ -457,11 +457,11 @@ All classes of the domain model must inherit from one of the following two class
 Repositories
 ------------
 
-All repositories inherit from :class:`Tx_Extbase_Persistence_Repository`. A repository is always
+All repositories inherit from :class:`\\TYPO3\\CMS\\Extbase\\Persistence\\Repository`. A repository is always
 resposible for precisely one type of domain object. The naming of the repositories is important:
-If the domain object is for example Blog (with full name :class:`Tx_BlogExample_Domain_Model_Blog`),
+If the domain object is for example Blog (with full name :class:`\\Ex\\BlogExample\\Domain\\Model\\Blog`),
 then the corresponding repository is named *BlogRepository* (with full name
-:class:`Tx_BlogExample_Domain_Repository_BlogRepository`).
+:class:`\\Ex\\BlogExample\\Domain\\Repository\\BlogRepository`).
 
 Public Repository API
 ~~~~~~~~~~~~~~~~~~~~~

--- a/Documentation/b-ExtbaseReference/Index.rst
+++ b/Documentation/b-ExtbaseReference/Index.rst
@@ -31,7 +31,7 @@ backend. Let's have a look at the following two files:
 
 :file:`ext_localconf.php`::
 
-	Tx_Extbase_Utility_Extension::configurePlugin(
+	\TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
 		$_EXTKEY,
 		$pluginName
 		$controllerActionCombinations,
@@ -51,7 +51,7 @@ same format as above, containing all the non-cached-actions.
 
 :file:`ext_tables.php`::
 
-	Tx_Extbase_Utility_Extension::registerPlugin(
+	\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
 		$_EXTKEY,
 		$pluginName,
 		$backendTitle
@@ -67,7 +67,7 @@ frontend plugin within the files :file:`ext_localconf.php` and :file:`ext_tables
 
 ::
 
-	Tx_Extbase_Utility_Extension::configurePlugin(
+	\TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
 		$_EXTKEY,
 		'Pi1',
 		array(
@@ -86,7 +86,7 @@ frontend plugin within the files :file:`ext_localconf.php` and :file:`ext_tables
 
 ::
 
-	Tx_Extbase_Utility_Extension::registerPlugin(
+	\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
 		$_EXTKEY,
 		'Pi1',
 		'A Blog Example'
@@ -190,29 +190,22 @@ Here are settings relevant to the persistence layer of Extbase.
 	This settings are used with individual classes. That includes in particular the
 	mapping of classes and property names to tables and field names.
 
-``persistence.classes.Tx_MyExt_Domain_Model_Foo.mapping.columns``
+``persistence.classes.Vendor\MyExt\Domain\Model\Foo.mapping.columns``
 	Here you can configure fields which differ from the regular naming conventions.
-	You use the form ``field_name.mapOnProperty = propertyName``. This is especially
-	necessary for Single Table Inheritance (see section "Using external data
-	sources" and "map class hierarchies" in Chapter 6).
+	You use the form ``field_name.mapOnProperty = propertyName``.
 
-``persistence.classes.Tx_MyExt_Domain_Model_Foo.mapping.recordType``
+``persistence.classes.Vendor\MyExt\Domain\Model\Foo.mapping.recordType``
 	Here you can specify a string literal, which - if set - should be stored in the
-	type field of the table. This is especially necessary for Single Table
-	Inheritance (see section "Using external data sources" and "map class
-	hierarchies" in Chapter 6).
+	type field of the table.
 
-``persistence.classes.Tx_MyExt_Domain_Model_Foo.mapping.tableName``
+``persistence.classes.Vendor\MyExt\Domain\Model\Foo.mapping.tableName``
 	Here you can set a table name which differs from the regular naming conventions.
-	This is especially necessary for Single Table Inheritance (see section "Using
-	external data sources" and "map class hierarchies" in Chapter 6).
 
-``persistence.classes.Tx_MyExt_Domain_Model_Foo.newRecordStoragePid``
+``persistence.classes.Vendor\MyExt\Domain\Model\Foo.newRecordStoragePid``
 	Page-ID in which new records of the given class should be saved.
 
-``persistence.classes.Tx_MyExt_Domain_Model_Foo.subclasses``
-	List all subclasses of the class given in the form *ClassName = ClassName* here
-	(see "map class hierarchies" in Chapter 6).
+``persistence.classes.Vendor\MyExt\Domain\Model\Foo.subclasses``
+	List all subclasses of the class given in the form *ClassName = ClassName*.
 
 ``persistence.enableAutomaticCacheClearing``
 	Enables the automatic cache clearing when changing data sets (see also the
@@ -280,15 +273,19 @@ Normally you will let your controllers inherit from ActionController. If you
 have special requirements that can not be realized with the ActionController,
 you should have a look at the controllers below.
 
-:class:`Tx_Extbase_MVC_Controller_ControllerInterface`
+:class:`\\TYPO3\\CMS\\Extbase\\Mvc\\Controller\\ControllerInterface`
 	The basic interface that must be implemented by all controllers.
 
-:class:`Tx_Extbase_MVC_Controller_AbstractController`
+:ref:`t3api:TYPO3\\CMS\\Extbase\\Mvc\\Controller\\AbstractController`
 	Abstract controller with basic functionality.
 
-:class:`Tx_Extbase_MVC_Controller_ActionController`
-	The most widely used controller in Extbase. An overview of its API is givben in
+:ref:`t3api:TYPO3\\CMS\\Extbase\\Mvc\\Controller\\ActionController`
+	The most widely used controller in Extbase. An overview of its API is given in
 	the following section.
+
+:ref:`t3api:TYPO3\\CMS\\Extbase\\Mvc\\Controller\\CommandController`
+	Extend this controller if you want to provide commands to the scheduler or command line
+	interface.
 
 ActionController API
 --------------------
@@ -310,23 +307,23 @@ you see the most important properties of the action controller:
 	fail. Default is errorAction. In general, it is not sensible to change this.
 
 ``$request``
-	Request object of type :class:`Tx_Extbase_MVC_RequestInterface`.
+	Request object of type :class:`\\TYPO3\\CMS\\Extbase\\Mvc\\RequestInterface`.
 
 ``$response``
-	Response object of type :class:`Tx_Extbase_MVC_ResponseInterface`.
+	Response object of type :class:`\\TYPO3\\CMS\\Extbase\\Mvc\\ResponseInterface`.
 
 ``$settings``
 	Domain-specific extension settings from TypoScript (as array).
 
 ``$view``
-	The view used (of type :class:`Tx_Extbase_MVC_View_ViewInterface`).
+	The view used of type :class:`\\TYPO3\\CMS\\Extbase\\Mvc\\View\\ViewInterface`.
 
 ``$viewObjectNamePattern``
 	If no fluid template is found for the current action, extbase attempts to find a
 	PHP-View-Class for the action. The naming scheme of the PHP-View-Class can be
 	changed here. By default names are used according to the scheme
-	*Tx@extension_View_@controller_@action_@format*. All string-parts marked with @
-	are replaced by the corresponding values​​. If no view class with this name is
+	*@vendor\@extension\View\@controller\@action@format*. All string-parts marked with @
+	are replaced by the corresponding values. If no view class with this name is
 	found, @format is removed from the pattern and again tried to find a view class
 	with that name.
 
@@ -350,7 +347,7 @@ Most important API methods of the action controller
 	Action-specific initialization, which is called only before the specific action.
 	Can be used to e.g. register arguments.
 
-:code:`initializeView(Tx_Extbase_MVC_ViewInterface $ view)`
+:code:`initializeView(\TYPO3\CMS\Extbase\Mvc\View\ViewInterface $ view)`
 	Initialization method to configure and initialize the passed view.
 
 :code:`redirect($actionName, $controllerName = NULL, $extensionName = NULL, array $arguments = NULL, $pageUid = NULL, $delay = 0, $statusCode = 303)`
@@ -387,16 +384,16 @@ of the specified method, as shown in Example B-3:
 	/**
 	  * Displays a form for creating a new blog
 	  *
-	  * @param Tx_BlogExample_Domain_Model_Blog $newBlog A fresh blog object which should be taken
+	  * @param \Ex\BlogExample\Domain\Model\Blog $newBlog A fresh blog object which should be taken
 	           as a basis for the form if it is set.
 	  * @return string An HTML form for creating a new blog
 	  * @dontvalidate $newBlog
 	  */
-	public function newAction(Tx_BlogExample_Domain_Model_Blog $newBlog = NULL) {
+	public function newAction(\Ex\BlogExample\Domain\Model\Blog $newBlog = NULL) {
 	  $this->view->assign('newBlog', $newBlog);
 	);
 
-	public function newAction(Tx_BlogExample_Domain_Model_Blog $newBlog = NULL) {
+	public function newAction(\Ex\BlogExample\Domain\Model\Blog $newBlog = NULL) {
 	  $this->view->assign('newBlog', $newBlog);
 	);
 
@@ -451,10 +448,10 @@ Domain model
 
 All classes of the domain model must inherit from one of the following two classes:
 
-:class:`Tx_Extbase_DomainModel_AbstractEntity`
+:class:`\\TYPO3\\CMS\\Extbase\\DomainObject\\AbstractEntity`
 	Is used if the object is an entity, i.e. possesses an identity.
 
-:class:`Tx_Extbase_DomainModel_AbstractValueObject`
+:class:`\\TYPO3\\CMS\\Extbase\\DomainObject\\AbstractValueObject`
 	Is used if the object is a ValueObject, i.e. if its identity is defined by all of its properties.
 	ValueObjects are immutable.
 
@@ -506,7 +503,7 @@ to formulate a request:
 
 ::
 
-	public function findWithCategory(Tx_MyExt_Domain_Model_Category $region) {
+	public function findWithCategory(\Ex\BlogExample\Domain\Model\Category $region) {
 	  $query = $this->createQuery();
 	  $query->matching($query->contains('categories', $category));
 	  return $query->execute();
@@ -567,7 +564,7 @@ Validation
 You can write your own validators for domain models. These must be located in
 the folder :file:`Domain/Validator/`, they must be named exactly as the corresponding
 Domain model, but with the suffix Validator and implement the interface
-:class:`Tx_Extbase_Validation_Validator_ValidatorInterface`. For more details, see the
+:class:`\\TYPO3\\CMS\\Extbase\\Validation\\Validator\\ValidatorInterface`. For more details, see the
 following Section.
 
 Validation API
@@ -576,7 +573,7 @@ Validation API
 Extbase provides a generic validation system which is used in many places in
 Extbase and Fluid. Extbase provides validators for common data types, but you
 can also write your own validators. Each Validator implements the
-:class:`Tx_Extbase_Validation_Validator_ValidatorInterface` that defines the following
+:class:`\\TYPO3\\CMS\\Extbase\\Validation\\Validator\\ValidatorInterface` that defines the following
 methods:
 
 :code:`getErrors()`
@@ -592,7 +589,7 @@ methods:
 
 You can call Validators in your own code with the method
 :code:`createValidator($validatorName, $validatorOptions)` in
-:class:`Tx_Extbase_Validation_ValidatorResolver`. Though in general, this is not
+:class:`\\TYPO3\\CMS\\Extbase\\Validation\\ValidatorResolver`. Though in general, this is not
 necessary. Validators are often used in conjunction with domain objects and
 controller actions.
 
@@ -607,7 +604,9 @@ example:
 
 ::
 
-	class Tx_BlogExample_Domain_Model_Blog extends Tx_Extbase_DomainObject_AbstractEntity {
+	namespace Ex\BlogExample\Domain\Model;
+
+	class Blog extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity {
 		/**
 		 * The blog's title.
 		 *
@@ -653,14 +652,14 @@ Localization
 
 Multilingual websites are widespread nowadays, which means that the
 web-available texts have to be localized. Extbase provides the helper class
-:class:`Tx_Extbase_Utility_Localization` for the translation of the labels. In addition,
-there is the fluid ViewHelper translate, with the help of whom you can use that
+:class:`\\TYPO3\\CMS\\Extbase\\Utility\\LocalizationUtility` for the translation of the labels. In addition,
+there is the Fluid ViewHelper translate, with the help of whom you can use that
 functionality in templates.
 
 The localization class has only one public static method called translate, which
 does all the translation. The method can be called like this:
 
-``Tx_Extbase_Utility_Localization::translate($key, $extensionName, $arguments=NULL)``
+``\TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate($key, $extensionName, $arguments=NULL)``
 
 ``$key``
 	The identifier to be translated. If then format *LLL:path:key* is given, then this

--- a/Documentation/b-ExtbaseReference/Index.rst
+++ b/Documentation/b-ExtbaseReference/Index.rst
@@ -41,7 +41,7 @@ backend. Let's have a look at the following two files:
 In addition to the extension key and a unique name of the plugin (line 2 and 3)
 the allowed combinations of the controller and actions are determined.
 ``$controllerActionCombinations`` is an associative array. The Keys of this array
-are the allowed Controllers, and the values ​​are a comma-separated list of
+are the allowed Controllers, and the values are a comma-separated list of
 allowed actions per Controller. The first action of the first controller is the
 default action.
 
@@ -403,7 +403,7 @@ but also complex object types (see also the section "validating domain objects" 
 In addition, on actions showing the forms used to create or edit domain View objects, the validation of
 domain objects must be explicitly disabled - therefore the annotation *@dontvalidate* is necessary.
 
-Default values ​​can, as usual in PHP, just be indicated in the method signature. In the above case,
+Default values can, as usual in PHP, just be indicated in the method signature. In the above case,
 the default value of the parameter ``$newBlog`` is set to NULL. If an action returns NULL or nothing,
 then automatically ``$this->view->render()`` is called, and thus the view is rendered.
 
@@ -525,7 +525,7 @@ generating a single condition are available:
 	In the case of strings you can specified additionally, whether the comparison is case-sensitive.
 
 :code:`$query->in($propertyName, $operand);`
-	Checks if the value of the property _$propertyName_ is present within the series of values ​​in ``$operand``.
+	Checks if the value of the property _$propertyName_ is present within the series of values in ``$operand``.
 
 :code:`$query->contains($propertyName, $operand);`
 	Checks whether the specified property ``$propertyName`` containing a collection has an element

--- a/Documentation/b-ExtbaseReference/Index.rst
+++ b/Documentation/b-ExtbaseReference/Index.rst
@@ -1,6 +1,7 @@
 .. Todo: Interfaces are currently not in the inventory of t3api.
     We should reference them, as soon as they are inside. Xavier already rendered them, but I didn't
     get the url running for latest.
+    We also should ref all code to the API.
 
 .. include:: ../Includes.txt
 .. _extbase_reference:
@@ -24,6 +25,12 @@ Registration of frontend plugins
 
 .. Todo: Add section about backend modules.
 
+In classical TYPO3 extensions the frontend functionality is divided into
+several frontend plugins. Normally each has a separate code base.
+In contrast, there is only one code base in Extbase (a series of controllers and
+actions). Nevertheless, it is possible to group controllers and actions
+to make it possible to have multiple frontend plugins.
+
 .. sidebar:: Why two files?
 
     You may wonder why you need to edit both, file :file:`ext_localconf.php` and file
@@ -36,12 +43,6 @@ Registration of frontend plugins
     For further information, check out :ref:`Extenion configuration files
     <t3coreapi:extension-configuration-files>`.
 
-In classical TYPO3 extensions the frontend functionality is divided into
-several frontend plugins. Normally each has a separate code base.
-In contrast, there is only one code base in Extbase (a series of controllers and
-actions). Nevertheless, it is possible to group controllers and actions
-to make it possible to have multiple frontend plugins.
-
 For the definition of a plugin, the files :file:`ext_localconf.php` and :file:`ext_tables.php`
 have to be adjusted.
 
@@ -53,7 +54,7 @@ backend. Let's have a look at the following two files:
 :file:`ext_localconf.php`::
 
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-        $_EXTKEY,
+        'Vendor' . $_EXTKEY,
         $pluginName
         $controllerActionCombinations,
         $uncachedActions
@@ -73,7 +74,7 @@ same format as above, containing all the non-cached-actions.
 :file:`ext_tables.php`::
 
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-        $_EXTKEY,
+        'Vendor' . $_EXTKEY,
         $pluginName,
         $backendTitle
     );
@@ -89,7 +90,7 @@ frontend plugin within the files :file:`ext_localconf.php` and :file:`ext_tables
 ::
 
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-        $_EXTKEY,
+        'Ex' . $_EXTKEY,
         'Blog',
         array(
             'Blog' => 'index,show,new,create,delete,deleteAll,edit,update,populate',
@@ -108,15 +109,14 @@ frontend plugin within the files :file:`ext_localconf.php` and :file:`ext_tables
 ::
 
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-        $_EXTKEY,
+        'Ex' . $_EXTKEY,
         'Blog',
         'A Blog Example'
     );
 
-The plugin name is ``Blog``. It is important that in :file:`ext_localconf.php` and
-:file:`ext_tables.php` the name is exactly the same. The default action is the action
-``index`` of the controller ``blog`` since this is the first element defined in the
-array and the first action in the list.
+The plugin name is ``Blog``. It is important that the name is exactly the same in
+:file:`ext_localconf.php` and :file:`ext_tables.php`. The default action is ``index`` of controller
+``blog`` since it's the first element defined in the array and the first action in the list.
 
 All actions which change data must not be cacheable. Above, this is for example
 the ``delete`` action in the ``blog`` controller. In the backend you can see "*A Blog
@@ -154,24 +154,30 @@ Posts the SysFolder *BLOGS* is configured. If an entry is changed, the cache of 
 :ref:`TCEMAIN.clearCacheCmd <t3tsconfig:pagetcemain-clearcachecmd>` for the SysFolder is evaluated.
 This contains a comma-separated list of Page IDs, for which the cache should be emptied. In this
 case, when updating a record in the SysFolder *BLOGS* (e.g.  Blogs, Posts, Comments), the cache of
-the page *Blog* (with ID 11) is cleared automatically, so the changes are immediately visible.
+the page *Blog*, with ID 11, is cleared automatically, so the changes are immediately visible.
 
 Even if the user enters incorrect data in a form (and this form will be
 displayed again), the cache of the current page is deleted to force a new
 representation of the form.
 
-The automatic cache clearing is enabled by default, you can use TypoScript
-configuration to disable it (see :ref:`features.skipDefaultArguments <features-skipDefaultArguments>`).
+The automatic cache clearing is enabled by default, you can use the TypoScript configuration
+:ref:`persistence.enableAutomaticCacheClearing <persistence-enableAutomaticCacheClearing>` to disable
+it.
 
 .. _typoscript_configuration:
 
 TypoScript Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Each Extbase based extension has some settings which can be modified using TypoScript. Many of these
+Each Extbase extension has some settings which can be modified using TypoScript. Many of these
 settings affect aspects of the internal Configuration of Extbase and Fluid. There is also a block
 ``settings`` in which you can set Extension specific settings, which can be accessed in the
 controllers and Templates of your extensions.
+
+.. tip::
+
+    These options are allways available. Integrators can use them to configure the behaviour, even
+    if not inteded or provided by the author of the extension.
 
 **plugin.tx_[lowercasedextensionname]**
 
@@ -226,7 +232,9 @@ Settings relevant to the persistence layer of Extbase.
     Page-ID in which new records of the given class should be saved.
 
 `persistence.classes.Vendor\MyExt\Domain\Model\Foo.subclasses`
-    List all subclasses of the class given in the form *ClassName = ClassName*.
+    List all subclasses of the class given in the form `Identifier = ClassName`.
+
+.. _persistence-enableAutomaticCacheClearing:
 
 `persistence.enableAutomaticCacheClearing`
     Enables the automatic cache clearing when changing data sets (see also the
@@ -282,9 +290,9 @@ View and template settings.
     :file:`extensionName/Resources/Private/Templates` is used. All layouts that are necessary
     for this extension should reside in this folder.
 
-    There is no fallback to the files that are delivered with an extension!
-    Therefore you need to copy all original templates to this folder before you set
-    this TypoScript setting.
+There is no fallback to the files that are delivered with an extension!
+Therefore you need to copy all original templates to this folder before you set
+this TypoScript setting.
 
 .. Todo: Add feature #66111, multiple paths for fluid.
 
@@ -303,7 +311,7 @@ _LOCAL_LANG
 
 Under this key you can modify localized strings for this extension.
 If you specify for example `plugin.tx_blogexample._LOCAL_LANG.default.read_more =
-More>>` then the standard translation for the key read_more is overwritten by the
+More>>` then the standard translation for the key `read_more` is overwritten by the
 string *More>>*.
 
 .. _class_hierarchy:
@@ -312,10 +320,10 @@ Class Hierarchy
 ^^^^^^^^^^^^^^^
 
 The MVC Framework is the heart of Extbase. Below we will give you an overview of
-the class hierarchy for the controllers and the API of the ActionControllers.
+the class hierarchy for the controllers and the API of the `ActionControllers`.
 
-Normally you will let your controllers inherit from ActionController. If you
-have special requirements that can not be realized with the ActionController,
+Normally you will let your controllers inherit from `ActionController`. If you
+have special requirements that can not be realized with the `ActionController`,
 you should have a look at the controllers below.
 
 :class:`\\TYPO3\\CMS\\Extbase\\Mvc\\Controller\\ControllerInterface`
@@ -360,7 +368,7 @@ you see the most important properties of the action controller:
     Response object of type :class:`\\TYPO3\\CMS\\Extbase\\Mvc\\ResponseInterface`.
 
 `$settings`
-    Domain-specific extension settings from TypoScript (as array).
+    Domain-specific extension settings from TypoScript (as array), see :ref:`typoscript_configuration-settings`.
 
 `$view`
     The view used of type :class:`\\TYPO3\\CMS\\Extbase\\Mvc\\View\\ViewInterface`.
@@ -380,42 +388,42 @@ you see the most important properties of the action controller:
 Most important API methods of action controller
 ---------------------------------------------------
 
-:code:`Action()`
+`Action()`
     Defines an action.
 
-:code:`errorAction()`
+`errorAction()`
     Standard error action. Needs to be adjusted only in very rare cases. The name of
     this method is defined by the property $errorMethodName.
 
-:code:`forward($actionName, $controllerName = NULL, $extensionName = NULL, array $arguments = NULL)`
+`forward($actionName, $controllerName = NULL, $extensionName = NULL, array $arguments = NULL)`
     Issues an immediate internal forwarding of the request to another controller.
 
-:code:`initializeAction()`
+`initializeAction()`
     Initialization method for all actions. Can be used to e.g. register arguments.
 
-:code:`initialize[actionName]Action()`
+`initialize[actionName]Action()`
     Action-specific initialization, which is called only before the specific action.
     Can be used to e.g. register arguments.
 
-:code:`initializeView(\TYPO3\CMS\Extbase\Mvc\View\ViewInterface $ view)`
+`initializeView(\TYPO3\CMS\Extbase\Mvc\View\ViewInterface $ view)`
     Initialization method to configure and initialize the passed view.
 
-:code:`redirect($actionName, $controllerName = NULL, $extensionName = NULL, array $arguments = NULL, $pageUid = NULL, $delay = 0, $statusCode = 303)`
+`redirect($actionName, $controllerName = NULL, $extensionName = NULL, array $arguments = NULL, $pageUid = NULL, $delay = 0, $statusCode = 303)`
     External HTTP redirect to another controller (immediately)
 
-:code:`redirectToURI($uri, $delay = 0, $statusCode = 303)`
+`redirectToURI($uri, $delay = 0, $statusCode = 303)`
     Redirect to full URI (immediately)
 
-:code:`resolveView()`
+`resolveView()`
     By overriding this method you can build and configure a completely individual
     view object. This method should return a complete view object. In general,
     however, it is sufficient to overwrite resolveViewObjectName().
 
-:code:`resolveViewObjectName()`
+`resolveViewObjectName()`
     Resolves the name of the view object, if no suitable fluid template could be
     found.
 
-:code:`throwStatus($statusCode, $statusMessage = NULL, $content = NULL)`
+`throwStatus($statusCode, $statusMessage = NULL, $content = NULL)`
     The specified HTTP status code is sent immediately.
 
 .. _class_hierarchy-actions:
@@ -423,7 +431,7 @@ Most important API methods of action controller
 Actions
 -------
 
-All public methods that end in action (for example `indexAction` or `showAction`),
+All public and protected methods that end in *action* (for example `indexAction` or `showAction`),
 are automatically registered as actions of the controller.
 
 Many of these actions have parameters. These appear as annotations in the Doc-Comment-Block
@@ -434,29 +442,29 @@ of the specified method, as shown in Example B-3:
 ::
 
     /**
-      * Displays a form for creating a new blog.
+      * Displays a form for creating a new blog, optionally prefilled with partial information.
       *
       * @param \Ex\BlogExample\Domain\Model\Blog $newBlog A fresh blog object which should be taken
       *        as a basis for the form if it is set.
       *
-      * @return string An HTML form for creating a new blog
+      * @return void
       *
-      * @dontvalidate $newBlog
+      * @ignorevalidation $newBlog
       */
     public function newAction(\Ex\BlogExample\Domain\Model\Blog $newBlog = NULL)
     {
         $this->view->assign('newBlog', $newBlog);
     )
 
-It is important to specify the full type in the *@param* annotation as this is used for the validation
+It is important to specify the full type in the `@param` annotation as this is used for the validation
 of the object. Note that not only simple data types such as String, Integer or Float can be validated,
-but also complex object types (see also the section "validating domain objects" in Chapter 9).
+but also complex object types (see also the section ":ref:`validating-domain-objects`" in Chapter 9).
 
-In addition, on actions showing the forms used to create or edit domain View objects, the validation of
-domain objects must be explicitly disabled - therefore the annotation *@dontvalidate* is necessary.
+In addition, on actions showing the forms used to create domain objects, the validation of domain
+objects must be explicitly disabled - therefore the annotation `@ignorevalidation` is necessary.
 
 Default values can, as usual in PHP, just be indicated in the method signature. In the above case,
-the default value of the parameter `$newBlog` is set to NULL. If an action returns NULL or nothing,
+the default value of the parameter `$newBlog` is set to NULL. If an action returns `NULL` or nothing,
 then automatically `$this->view->render()` is called, and thus the view is rendered.
 
 .. _class_hierarchy-define_initialization_code:
@@ -464,23 +472,22 @@ then automatically `$this->view->render()` is called, and thus the view is rende
 Define initialization code
 --------------------------
 
-Sometimes it is necessary to execute code before calling an action. This is the case, for example,
-if complex arguments must be registered or required classes must be instantiated.
+Sometimes it is necessary to execute code before calling an action. For example, if complex
+arguments must be registered or required classes must be instantiated.
 
-There is a generic initialization method called :code:`initializeAction()`, which is called after
-the registration of arguments, but before calling the appropriate action method itself. After that
-generic :code:`initializeAction()`, if it exists, a method named *initialize[ActionName]()* is called.
-Here you can perform action specific initializations (e.g. :code:`initializeShowAction()`).
-Only then the action itself is called.
+There is a generic initialization method called `initializeAction()`, which is called after
+the registration of arguments, but before calling the appropriate action method itself. After the
+generic `initializeAction()`, if it exists, a method named *initialize[ActionName]()* is called.
+Here you can perform action specific initializations (e.g. `initializeShowAction()`).
 
 .. _class_hierarchy-catching_validation_errors_with_error_action:
 
 Catching validation errors with errorAction
 -------------------------------------------
 
-If an argument validation error has occurred, the method :code:`errorAction()` is called. There,
+If an argument validation error has occurred, the method `errorAction()` is called. There,
 in `$this->argumentsMappingResults` you have a list of occurred warnings and errors of the argument
-mappings available. This default `errorAction` refers back to the last sent form, if the referrer
+mappings available. This default `errorAction` refers back to the referrer, if the referrer
 was sent with it.
 
 Application domain of the extension
@@ -490,13 +497,13 @@ The domain of the extension is always located below :file:`Classes/Domain`. This
 as follows:
 
 :file:`Model/`
-    Contains the domain model itself.
+    Contains the domain models itself.
 
 :file:`Repository/`
-    Contains the repositories to access the domain model.
+    Contains the repositories to access the domain models.
 
 :file:`Validator/`
-    Contains specific validators for the domain model.
+    Contains specific validators for the domain models.
 
 Domain model
 ------------
@@ -514,40 +521,40 @@ Repositories
 ------------
 
 All repositories inherit from :class:`\\TYPO3\\CMS\\Extbase\\Persistence\\Repository`. A repository is always
-resposible for precisely one type of domain object. The naming of the repositories is important:
-If the domain object is for example Blog (with full name :class:`\\Ex\\BlogExample\\Domain\\Model\\Blog`),
+responsible for precisely one type of domain object. The naming of the repositories is important:
+If the domain object is, for example, *Blog* (with full name `\\Ex\\BlogExample\\Domain\\Model\\Blog`),
 then the corresponding repository is named *BlogRepository* (with full name
-:class:`\\Ex\\BlogExample\\Domain\\Repository\\BlogRepository`).
+`\\Ex\\BlogExample\\Domain\\Repository\\BlogRepository`).
 
 Public Repository API
 ~~~~~~~~~~~~~~~~~~~~~
 
 Each repository provides the following public methods:
 
-:code:`add($object)`
+`add($object)`
     Adds a new object.
 
-:code:`findAll()` and :code:`countAll()`
+`findAll()` and `countAll()`
     returns all domain objects (or the number of them) it is responsible for.
 
-:code:`findByUid($uid)`
+`findByUid($uid)`
     Returns the domain object with this UID.
 
-:code:`findByProperty($propertyValue)` and :code:`countByProperty($propertyValue)`
+`findByProperty($propertyValue)` and `countByProperty($propertyValue)`
     Magic finder method. Finding all objects (or the number of them) for the property *property* having
     a value of `$propertyValue` and returns them in an array, or the number as an integer value.
 
-:code:`findOneByProperty($propertyValue)`
+`findOneByProperty($propertyValue)`
     Magic finder method. Finds the first object, for which the given property *property* has the value
-    $propertyValue.
+    `$propertyValue`.
 
-:code:`remove($object)` and :code:`removeAll()`
+`remove($object)` and `removeAll()`
     Deletes an object (or all objects) in the repository.
 
-:code:`replace($existingObject, $newObject)`
+`replace($existingObject, $newObject)`
     Replaces an object of the repositories with another.
 
-:code:`update($object)`
+`update($object)`
     Updates the persisted object.
 
 Custom find methods in repositories
@@ -576,50 +583,50 @@ Create a ``Query`` object within the repository through `$this->createQuery()`. 
 object a constraint using `$query->matching($constraint)`. The following comparison operations for
 generating a single condition are available:
 
-:code:`$query->equals($propertyName, $operand, $caseSensitive);`
-    Simple comparison between the value of the property provided by $propertyName and the operand.
+`$query->equals($propertyName, $operand, $caseSensitive);`
+    Simple comparison between the value of the property provided by `$propertyName` and the operand.
     In the case of strings you can specified additionally, whether the comparison is case-sensitive.
 
-:code:`$query->in($propertyName, $operand);`
-    Checks if the value of the property _$propertyName_ is present within the series of values in `$operand`.
+`$query->in($propertyName, $operand);`
+    Checks if the value of the property `$propertyName` is present within the series of values in `$operand`.
 
-:code:`$query->contains($propertyName, $operand);`
+`$query->contains($propertyName, $operand);`
     Checks whether the specified property `$propertyName` containing a collection has an element
     `$operand` within that collection.
 
-:code:`$query->like($propertyName, $operand);`
-    Comparison between the value of the property specified by $propertyName and a string $operand.
+`$query->like($propertyName, $operand);`
+    Comparison between the value of the property specified by `$propertyName` and a string $operand.
     In this string, the %-character is interpreted as placeholder (similar to * characters in search
     engines, in reference to the SQL syntax).
 
-:code:`$query->lessThan($propertyName, $operand);`
-    Checks if the value of the property $propertyName is less than the operand.
+`$query->lessThan($propertyName, $operand);`
+    Checks if the value of the property `$propertyName` is less than the operand.
 
-:code:`$query->lessThanOrEqual($propertyName, $operand);`
-    Checks if the value of the property $propertyName is less than or equal to the operand.
+`$query->lessThanOrEqual($propertyName, $operand);`
+    Checks if the value of the property `$propertyName` is less than or equal to the operand.
 
-:code:`$query->greaterThan($propertyName, $operand);`
-    Checks if the value of the property $propertyName is greater than the operand.
+`$query->greaterThan($propertyName, $operand);`
+    Checks if the value of the property `$propertyName` is greater than the operand.
 
-:code:`$query->greaterThanOrEqual($propertyName, $operand);`
-    Checks if the value of the property $propertyName is greater than or equal to the operand.
+`$query->greaterThanOrEqual($propertyName, $operand);`
+    Checks if the value of the property `$propertyName` is greater than or equal to the operand.
 
 Since 1.1 `$propertyName` is not necessarily only a simple property-name but also can be a "property path".
     Example: `$query->equals('categories.title', 'tools')` searches for objects having a category titled
     "tools" assigned. If necessary, you can combine multiple conditions with boolean operations.
 
-:code:`$query->logicalAnd($constraint1, $constraint2);`
+`$query->logicalAnd($constraint1, $constraint2);`
     Two conditions are joined with a logical *and*, it gives back the resulting condition. Since Extbase
     1.1 also an array of conditions is allowed.
 
-:code:`$query->logicalOr($constraint1, $constraint2);`
+`$query->logicalOr($constraint1, $constraint2);`
     Two conditions are joined with a logical *or*, it gives back the resulting condition. Since Extbase
     1.1 also an array of conditions is allowed.
 
-:code:`$query->logicalNot($constraint);`
+`$query->logicalNot($constraint);`
     Returns a condition that inverts the result of the given condition (logical *not*).
 
-In the section "Individual queries," in Chapter 6  you can find a comprehensive example for building queries.
+In the section ":ref:`individual_database_queries`" in Chapter 6 you can find a comprehensive example for building queries.
 
 Validation
 ^^^^^^^^^^
@@ -633,34 +640,38 @@ following Section.
 Validation API
 --------------
 
-Extbase provides a generic validation system which is used in many places in
-Extbase and Fluid. Extbase provides validators for common data types, but you
-can also write your own validators. Each Validator implements the
-:class:`\\TYPO3\\CMS\\Extbase\\Validation\\Validator\\ValidatorInterface` that defines the following
-methods:
+.. todo: Add new API must haves, empty values and configure options, etc.
 
-:code:`getErrors()`
+Extbase provides a generic validation system which is used in many places in Extbase. Extbase
+provides validators for common data types, but you can also write your own validators. Each
+Validator implements the :class:`\\TYPO3\\CMS\\Extbase\\Validation\\Validator\\ValidatorInterface`
+that defines the following methods:
+
+.. note::
+
+    The API for Validation has changed slightly, we will update the reference accordingly.
+
+`getErrors()`
     Returns any error messages of the last validation.
 
-:code:`isValid($value)`
+`isValid($value)`
     Checks whether the object that was passed to the validator is valid. If yes,
     returns true, otherwise false.
 
-:code:`setOptions(array $validationOptions)`
+`setOptions(array $validationOptions)`
     Sets specific options for the validator. These options apply to any further call
     of the method isValid().
 
-You can call Validators in your own code with the method
-:code:`createValidator($validatorName, $validatorOptions)` in
-:class:`\\TYPO3\\CMS\\Extbase\\Validation\\ValidatorResolver`. Though in general, this is not
-necessary. Validators are often used in conjunction with domain objects and
+You can call Validators in your own code with the method `createValidator($validatorName,
+$validatorOptions)` in :class:`\\TYPO3\\CMS\\Extbase\\Validation\\ValidatorResolver`. Though in
+general, this is not necessary. Validators are often used in conjunction with domain objects and
 controller actions.
 
 Validation of model properties
 ------------------------------
 
 You can define simple validation rules in the domain model by annotation. For
-this, you use the annotation *@validate* with properties of the object. A brief
+this, you use the annotation `@validate` with properties of the object. A brief
 example:
 
 *Example B-4: validation in the domain object*
@@ -685,43 +696,43 @@ example:
         // the class continues here
     }
 
-In this code section, the validators for the $title attribute of the Blog object
-is defined. $title must be a text (ie, no HTML is allowed), and also the length
-of the string is checked with the StringLength-Validator (it must be between 1
-and 80 characters). Several validators for a property can be separated by
-commas. Parameter of the validators are set in parentheses. You can omit the
-quotes for validator options if they are superfluous as in the example above.
-If complex validation rules are necessary (for example, multiple fields to be
-checked for equality), you must implement your own validator.
+In this code section, the validators for the `$title` attribute of the Blog object is defined. `$title`
+must be a text (ie, no HTML is allowed), and also the length of the string is checked with the
+`StringLength`-Validator (it must be between 1 and 80 characters). Several validators for a property
+can be separated by commas. Parameter of the validators are set in parentheses. You can omit the
+quotes for validator options if they are superfluous as in the example above. If complex validation
+rules are necessary (for example, multiple fields to be checked for equality), you must implement
+your own validator.
 
 Validation of controller arguments
 ----------------------------------
 
-Each controller argument is validated by the following rules: If the argument
-has a simple type (string, integer, etc.), this type is checked. If the argument
-is a domain object, the annotation *@validate* in the domain object is taken into
-account and - if set - the appropriate validator in the folder :file:`Domain/Validator`
-for the existing domain object is run. If there is set an annotation
-*@dontvalidate* for the argument, no validation is done. Additional validation
-rules can be specified via further *@validate* annotations in the methods PHPDoc
-block. The syntax is *@validate $variableName Validator1, Validator2, ...* The
-syntax is almost the same as with validators in the domain model, you only needs
-to set explicitly the variable name.
+Each controller argument is validated by the following rules:
 
-If the arguments of an action can not be validated, then the errorAction is
-executed, which will usually jump back to the last screen. It is important that
-validation is not performed in certain cases. Further information for the usage
-of the annotation *@dontvalidate* see 'case studies Example: Editing an existing
-object' in Chapter 9
+* If the argument has a simple type (string, integer, etc.), this type is checked.
+* If the argument is a domain object, the annotations `@validate` in the domain object is taken into
+  account and - if set - the appropriate validator in the folder :file:`Domain/Validator` for the
+  existing domain object is run.
+* If there is set an annotation `@ignorevalidation` for the argument, no validation is done.
+* Additional validation rules can be specified via further `@validate` annotations in the methods
+  PHPDoc block. The syntax is *@validate $variableName Validator1, Validator2, ...* The syntax is
+  almost the same as with validators in the domain model, you only needs to set explicitly the
+  variable name.
 
+If the arguments of an action can not be validated, then the `errorAction` is executed, which will
+usually jump back to the last screen. It is important that validation is not performed in certain
+cases. Further information for the usage of the annotation `@dontvalidate` see
+":ref:`case_study-edit_an_existing_object`" in Chapter 9.
 
 Localization
 ^^^^^^^^^^^^
 
+.. todo: Link to core documentation of language files.
+
 Multilingual websites are widespread nowadays, which means that the
 web-available texts have to be localized. Extbase provides the helper class
 :class:`\\TYPO3\\CMS\\Extbase\\Utility\\LocalizationUtility` for the translation of the labels. In addition,
-there is the Fluid ViewHelper translate, with the help of whom you can use that
+there is the Fluid ViewHelper `<f:translate>`, with the help of whom you can use that
 functionality in templates.
 
 The localization class has only one public static method called translate, which
@@ -731,16 +742,13 @@ does all the translation. The method can be called like this:
 
 `$key`
     The identifier to be translated. If then format *LLL:path:key* is given, then this
-    identifier is used and the parameter $extensionName is ignored. Otherwise, the
-    file :file:`Resources/Private/Language/locallang.xml` from the given extension is loaded
+    identifier is used and the parameter `$extensionName` is ignored. Otherwise, the
+    file :file:`Resources/Private/Language/locallang.xlf` from the given extension is loaded
     and the resulting text for the given key in the current language returned.
 
 `$extensionName`
     The extension name. It can be fetched from the request.
 
 `$arguments`
-    Allows you to specify an array of arguments passed to the function vsprintf. Allows you to fill
-    wildcards in localized strings with values.
-
-In Fluid there is the translate ViewHelper, which works by the same rules. For a
-case study for localization, see Chapter 9.
+    Allows you to specify an array of arguments passed to the function `vsprintf`. Allows you to
+    fill wildcards in localized strings with values.

--- a/Documentation/b-ExtbaseReference/Index.rst
+++ b/Documentation/b-ExtbaseReference/Index.rst
@@ -12,8 +12,8 @@ Extbase extensions.
 
 .. _configuration_of_frontend_plugins:
 
-Configuration of frontend plugins
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Registration of frontend plugins
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In classical TYPO3 extensions the front-end functionality is divided into
 several front-end Plugins. Normally each has a separate code base.
@@ -97,10 +97,14 @@ The plugin name is pi1. It is important that in :file:`ext_localconf.php` and
 index of the Controller *Blog* since this is the first element defined in the
 array and the first action in the list.
 
+Caching of actions and records
+------------------------------
+
 All actions which change data must not be cacheable. Above, this is for example
 the delete action in the blog controller. In the backend now you can see A Blog
 Example in the list of plugins (see Figure B-1).
 
+.. Todo: Add section about backend modules.
 
 .. figure:: /Images/b-ExtbaseReference/figure-b-1.png
 	:align: center
@@ -167,18 +171,20 @@ TypoScript path. The "lowercased extension name" is the extension key with no
 underscore (_), as for example in blogexample. The configuration is divided into
 the following sections:
 
+features
+--------
 
-
-``features``
-	Activate features for extbase or a specific plugin.
+Activate features for extbase or a specific plugin.
 
 ``features.skipDefaultArguments``
 	Skip default arguments in URLs. If a link to the default controller or action
 	is created, the parameters are omitted.
 	Default is ``false``.
 
-``persistence``
-	Here are settings relevant to the persistence layer of Extbase.
+persistence
+-----------
+
+Here are settings relevant to the persistence layer of Extbase.
 
 ``persistence.classes``
 	This settings are used with individual classes. That includes in particular the
@@ -217,13 +223,17 @@ the following sections:
 	List of Page-IDs, from which all records are read (see the section "Creating the
 	repositories" in Chapter 6).
 
-``settings``
-	Here reside are all the domain-specific extension settings. This setting are
-	available as an array in the controllers in ``$this->settings`` and in any Fluid
-	template with ``{settings}``.
+settings
+--------
 
-``view``
-	View and template settings.
+Here reside are all the domain-specific extension settings. This setting are
+available as an array in the controllers in ``$this->settings`` and in any Fluid
+template with ``{settings}``.
+
+view
+----
+
+View and template settings.
 
 ``view.layoutRootPath``
 	This can be used to specify the root path for all fluid layouts in this
@@ -252,20 +262,19 @@ the following sections:
 	Therefore you need to copy all original templates to this folder before you set
 	this TypoScript setting.
 
-``_LOCAL_LANG``
-	Under this key you can modify localized strings for this extension.
-	If you specify for example ``plugin.tx_blogexample._LOCAL_LANG.default.read_more =
-	More>>`` then the standard translation for the key read_more is overwritten by the
-	string *More>>*.
+_LOCAL_LANG
+-----------
 
-Using Model View Controller
----------------------------
-
-The MVC Framework is the heart of Extbase. Below we will give you an overview of
-the class hierarchy for the controllers and the API of the ActionControllers.
+Under this key you can modify localized strings for this extension.
+If you specify for example ``plugin.tx_blogexample._LOCAL_LANG.default.read_more =
+More>>`` then the standard translation for the key read_more is overwritten by the
+string *More>>*.
 
 Class Hierarchy
 ^^^^^^^^^^^^^^^
+
+The MVC Framework is the heart of Extbase. Below we will give you an overview of
+the class hierarchy for the controllers and the API of the ActionControllers.
 
 Normally you will let your controllers inherit from ActionController. If you
 have special requirements that can not be realized with the ActionController,
@@ -282,7 +291,7 @@ you should have a look at the controllers below.
 	the following section.
 
 ActionController API
-^^^^^^^^^^^^^^^^^^^^
+--------------------
 
 The action controller is usually the base class for your own controller. Below
 you see the most important properties of the action controller:
@@ -321,7 +330,8 @@ you see the most important properties of the action controller:
 	found, @format is removed from the pattern and again tried to find a view class
 	with that name.
 
-Now follow the most important API methods of the action controller:
+Most important API methods of the action controller
+---------------------------------------------------
 
 :code:`Action()`
 	Defines an action.
@@ -361,9 +371,8 @@ Now follow the most important API methods of the action controller:
 :code:`throwStatus($statusCode, $statusMessage = NULL, $content = NULL)`
 	The specified HTTP status code is sent immediately.
 
-
 Actions
-^^^^^^^
+-------
 
 All public methods that end in action (for example ``indexAction`` or ``showAction``),
 are automatically registered as actions of the controller.
@@ -458,6 +467,9 @@ If the domain object is for example Blog (with full name :class:`Tx_BlogExample_
 then the corresponding repository is named *BlogRepository* (with full name
 :class:`Tx_BlogExample_Domain_Repository_BlogRepository`).
 
+Public Repository API
+~~~~~~~~~~~~~~~~~~~~~
+
 Each repository provides the following public methods:
 
 :code:`add($object)`
@@ -485,6 +497,9 @@ Each repository provides the following public methods:
 
 :code:`update($object)`
 	Updates the persisted object.
+
+Custom find methods in repositories
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A repository can be extended by own finder methods. Within this methods you can use the ``Query`` object,
 to formulate a request:
@@ -546,7 +561,7 @@ Since 1.1 ``$propertyName`` is not necessarily only a simple property-name but a
 
 In the section "Individual queries," in Chapter 6  you can find a comprehensive example for building queries.
 
-Validators
+Validation
 ^^^^^^^^^^
 
 You can write your own validators for domain models. These must be located in
@@ -555,8 +570,8 @@ Domain model, but with the suffix Validator and implement the interface
 :class:`Tx_Extbase_Validation_Validator_ValidatorInterface`. For more details, see the
 following Section.
 
-Validation
-----------
+Validation API
+--------------
 
 Extbase provides a generic validation system which is used in many places in
 Extbase and Fluid. Extbase provides validators for common data types, but you
@@ -581,8 +596,8 @@ You can call Validators in your own code with the method
 necessary. Validators are often used in conjunction with domain objects and
 controller actions.
 
-Validating properties of the domain model
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Validation of model properties
+------------------------------
 
 You can define simple validation rules in the domain model by annotation. For
 this, you use the annotation *@validate* with properties of the object. A brief
@@ -613,7 +628,7 @@ If complex validation rules are necessary (for example, multiple fields to be
 checked for equality), you must implement your own validator.
 
 Validation of controller arguments
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+----------------------------------
 
 Each controller argument is validated by the following rules: If the argument
 has a simple type (string, integer, etc.), this type is checked. If the argument
@@ -634,7 +649,7 @@ object' in Chapter 9
 
 
 Localization
-------------
+^^^^^^^^^^^^
 
 Multilingual websites are widespread nowadays, which means that the
 web-available texts have to be localized. Extbase provides the helper class

--- a/Documentation/b-ExtbaseReference/Index.rst
+++ b/Documentation/b-ExtbaseReference/Index.rst
@@ -174,7 +174,7 @@ the following sections:
 features
 --------
 
-Activate features for extbase or a specific plugin.
+Activate features for Extbase or a specific plugin.
 
 ``features.skipDefaultArguments``
 	Skip default arguments in URLs. If a link to the default controller or action
@@ -242,7 +242,7 @@ View and template settings.
 
 ``view.pluginNamespace``
 	This can be used to specify an alternative namespace for the plugin.
-	Use this to shorten the extbase default plugin namespace or to access
+	Use this to shorten the Extbase default plugin namespace or to access
 	arguments from other extensions by setting this option to their namespace.
 
 ``view.templateRootPath``
@@ -319,7 +319,7 @@ you see the most important properties of the action controller:
 	The view used of type :class:`\\TYPO3\\CMS\\Extbase\\Mvc\\View\\ViewInterface`.
 
 ``$viewObjectNamePattern``
-	If no fluid template is found for the current action, extbase attempts to find a
+	If no fluid template is found for the current action, Extbase attempts to find a
 	PHP-View-Class for the action. The naming scheme of the PHP-View-Class can be
 	changed here. By default names are used according to the scheme
 	*@vendor\@extension\View\@controller\@action@format*. All string-parts marked with @

--- a/Documentation/b-ExtbaseReference/Index.rst
+++ b/Documentation/b-ExtbaseReference/Index.rst
@@ -31,12 +31,12 @@ backend. Let's have a look at the following two files:
 
 :file:`ext_localconf.php`::
 
-	\TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-		$_EXTKEY,
-		$pluginName
-		$controllerActionCombinations,
-		$uncachedActions
-	}
+    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
+        $_EXTKEY,
+        $pluginName
+        $controllerActionCombinations,
+        $uncachedActions
+    }
 
 In addition to the extension key and a unique name of the plugin (line 2 and 3)
 the allowed combinations of the controller and actions are determined.
@@ -51,11 +51,11 @@ same format as above, containing all the non-cached-actions.
 
 :file:`ext_tables.php`::
 
-	\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-		$_EXTKEY,
-		$pluginName,
-		$backendTitle
-	);
+    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
+        $_EXTKEY,
+        $pluginName,
+        $backendTitle
+    );
 
 The extension key and $pluginName must be completely identical to the definition
 in :file:`ext_localconf.php`. $backendTitle defines the displayed name of the plugin in
@@ -67,32 +67,32 @@ frontend plugin within the files :file:`ext_localconf.php` and :file:`ext_tables
 
 ::
 
-	\TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-		$_EXTKEY,
-		'Pi1',
-		array(
-			'Blog' => 'index,show,new,create,delete,deleteAll,edit,update,populate',
-			'Post' => 'index,show,new,create,delete,edit,update',
-			'Comment' => 'create',
-		),
-		array(
-			'Blog' => 'delete,deleteAll,edit,update,populate',
-			'Post' => 'show,delete,edit,update',
-			'Comment' => 'create',
-		)
-	);
+    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
+        $_EXTKEY,
+        'Blog',
+        array(
+            'Blog' => 'index,show,new,create,delete,deleteAll,edit,update,populate',
+            'Post' => 'index,show,new,create,delete,edit,update',
+            'Comment' => 'create',
+        ),
+        array(
+            'Blog' => 'delete,deleteAll,edit,update,populate',
+            'Post' => 'show,delete,edit,update',
+            'Comment' => 'create',
+        )
+    );
 
 *Example B-2: Configuration of an extension in the file ext_tables.php*
 
 ::
 
-	\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-		$_EXTKEY,
-		'Pi1',
-		'A Blog Example'
-	);
+    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
+        $_EXTKEY,
+        'Blog',
+        'A Blog Example'
+    );
 
-The plugin name is pi1. It is important that in :file:`ext_localconf.php` and
+The plugin name is ``Blog``. It is important that in :file:`ext_localconf.php` and
 :file:`ext_tables.php` the name is exactly the same. The default action is the action
 index of the Controller *Blog* since this is the first element defined in the
 array and the first action in the list.
@@ -381,21 +381,20 @@ of the specified method, as shown in Example B-3:
 
 ::
 
-	/**
-	  * Displays a form for creating a new blog
-	  *
-	  * @param \Ex\BlogExample\Domain\Model\Blog $newBlog A fresh blog object which should be taken
-	           as a basis for the form if it is set.
-	  * @return string An HTML form for creating a new blog
-	  * @dontvalidate $newBlog
-	  */
-	public function newAction(\Ex\BlogExample\Domain\Model\Blog $newBlog = NULL) {
-	  $this->view->assign('newBlog', $newBlog);
-	);
-
-	public function newAction(\Ex\BlogExample\Domain\Model\Blog $newBlog = NULL) {
-	  $this->view->assign('newBlog', $newBlog);
-	);
+    /**
+      * Displays a form for creating a new blog.
+      *
+      * @param \Ex\BlogExample\Domain\Model\Blog $newBlog A fresh blog object which should be taken
+      *        as a basis for the form if it is set.
+      *
+      * @return string An HTML form for creating a new blog
+      *
+      * @dontvalidate $newBlog
+      */
+    public function newAction(\Ex\BlogExample\Domain\Model\Blog $newBlog = NULL)
+    {
+        $this->view->assign('newBlog', $newBlog);
+    );
 
 It is important to specify the full type in the *@param* annotation as this is used for the validation
 of the object. Note that not only simple data types such as String, Integer or Float can be validated,
@@ -503,11 +502,19 @@ to formulate a request:
 
 ::
 
-	public function findWithCategory(\Ex\BlogExample\Domain\Model\Category $region) {
-	  $query = $this->createQuery();
-	  $query->matching($query->contains('categories', $category));
-	  return $query->execute();
-	}
+    /**
+     * Find blogs, which have the given category.
+     *
+     * @param \Ex\BlogExample\Domain\Model\Category $category
+     *
+     * @return \TYPO3\CMS\Extbase\Persistence\Generic\QueryResult
+     */
+    public function findWithCategory(\Ex\BlogExample\Domain\Model\Category $category)
+    {
+        $query = $this->createQuery();
+        $query->matching($query->contains('categories', $category));
+        return $query->execute();
+    }
 
 Create a ``Query`` object within the repository through ``$this->createQuery()``. You can give the query
 object a constraint using ``$query->matching($constraint)``. The following comparison operations for
@@ -604,18 +611,23 @@ example:
 
 ::
 
-	namespace Ex\BlogExample\Domain\Model;
+    namespace Ex\BlogExample\Domain\Model;
 
-	class Blog extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity {
-		/**
-		 * The blog's title.
-		 *
-		 * @var string
-		 * @validate Text, StringLength(minimum = 1, maximum = 80)
-		 */
-		protected $title;
-		// the class continues here
-	};
+    /**
+     * A single blog which has multiple posts and can be read by users.
+     */
+    class Blog extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
+    {
+        /**
+         * The blog's title.
+         *
+         * @var string
+         * @validate Text, StringLength(minimum = 1, maximum = 80)
+         */
+        protected $title;
+
+        // the class continues here
+    };
 
 In this code section, the validators for the $title attribute of the Blog object
 is defined. $title must be a text (ie, no HTML is allowed), and also the length

--- a/Documentation/b-ExtbaseReference/Index.rst
+++ b/Documentation/b-ExtbaseReference/Index.rst
@@ -2,6 +2,7 @@
     We should reference them, as soon as they are inside. Xavier already rendered them, but I didn't
     get the url running for latest.
 
+.. include:: ../Includes.txt
 .. _extbase_reference:
 
 Extbase Reference
@@ -60,7 +61,7 @@ backend. Let's have a look at the following two files:
 
 In addition to the extension key and a unique name of the plugin (line 2 and 3),
 the allowed combinations of the controller and actions are determined.
-``$controllerActionCombinations`` is an associative array. The Keys of this array
+`$controllerActionCombinations` is an associative array. The Keys of this array
 are the allowed controllers, and the values are a comma-separated list of
 allowed actions per controller. The first action of the first controller is the
 default action.
@@ -77,8 +78,8 @@ same format as above, containing all the non-cached-actions.
         $backendTitle
     );
 
-The extension key and ``$pluginName`` must be completely identical to the definition
-in :file:`ext_localconf.php`. ``$backendTitle`` defines the displayed name of the plugin in
+The extension key and `$pluginName` must be completely identical to the definition
+in :file:`ext_localconf.php`. `$backendTitle` defines the displayed name of the plugin in
 the Backend.
 Below there is a complete configuration example for the registration of a
 frontend plugin within the files :file:`ext_localconf.php` and :file:`ext_tables.php`.
@@ -188,16 +189,16 @@ Activate features for Extbase or a specific plugin.
 
 .. _features-skipDefaultArguments:
 
-``features.skipDefaultArguments``
+`features.skipDefaultArguments`
     Skip default arguments in URLs. If a link to the default controller or action is created, the
     parameters are omitted.
-    Default is ``false``.
+    Default is `false`.
 
 .. _features-ignoreAllEnableFieldsInBe:
 
-``features.ignoreAllEnableFieldsInBe``
+`features.ignoreAllEnableFieldsInBe`
     Ignore the enable fields in backend.
-    Default is ``false``.
+    Default is `false`.
 
 .. _typoscript_configuration-persistence:
 
@@ -206,33 +207,33 @@ persistence
 
 Settings relevant to the persistence layer of Extbase.
 
-``persistence.classes``
+`persistence.classes`
     This settings are used with individual classes. That includes in particular the
     mapping of classes and property names to tables and field names.
 
-``persistence.classes.Vendor\MyExt\Domain\Model\Foo.mapping.columns``
+`persistence.classes.Vendor\MyExt\Domain\Model\Foo.mapping.columns`
     Configure fields which differ from the regular naming conventions.
-    Use the form ``field_name.mapOnProperty = propertyName``.
+    Use the form `field_name.mapOnProperty = propertyName`.
 
-``persistence.classes.Vendor\MyExt\Domain\Model\Foo.mapping.recordType``
+`persistence.classes.Vendor\MyExt\Domain\Model\Foo.mapping.recordType`
     Specify a string literal, which - if set - should be stored in the
     type field of the table.
 
-``persistence.classes.Vendor\MyExt\Domain\Model\Foo.mapping.tableName``
+`persistence.classes.Vendor\MyExt\Domain\Model\Foo.mapping.tableName`
     Set a table name which differs from the regular naming conventions.
 
-``persistence.classes.Vendor\MyExt\Domain\Model\Foo.newRecordStoragePid``
+`persistence.classes.Vendor\MyExt\Domain\Model\Foo.newRecordStoragePid`
     Page-ID in which new records of the given class should be saved.
 
-``persistence.classes.Vendor\MyExt\Domain\Model\Foo.subclasses``
+`persistence.classes.Vendor\MyExt\Domain\Model\Foo.subclasses`
     List all subclasses of the class given in the form *ClassName = ClassName*.
 
-``persistence.enableAutomaticCacheClearing``
+`persistence.enableAutomaticCacheClearing`
     Enables the automatic cache clearing when changing data sets (see also the
     section ":ref:`caching_of_actions_and_records`" above in this chapter).
-    Default is ``true``.
+    Default is `true`.
 
-``persistence.storagePid``
+`persistence.storagePid`
     List of Page-IDs, from which all records are read (see the section
     ":ref:`Procedure to fetch objects <procedure_to_fetch_objects>`" in Chapter 6).
 
@@ -242,8 +243,8 @@ settings
 --------
 
 Here reside are all the domain-specific extension settings. This setting are
-available as an array in the controllers in ``$this->settings`` and in any Fluid
-template with ``{settings}``.
+available as an array in the controllers in `$this->settings` and in any Fluid
+template with `{settings}`.
 
 .. tip::
 
@@ -258,24 +259,24 @@ view
 
 View and template settings.
 
-``view.layoutRootPath``
+`view.layoutRootPath`
     This can be used to specify the root path for all fluid layouts in this
     extension. If nothing is specified, the path
     :file:`extensionName/Resources/Private/Layouts` is used. All layouts that are necessary
     for this extension should reside in this folder.
 
-``view.partialRootPath``
+`view.partialRootPath`
     This can be used to specify the root path for all fluid partials in this
     extension. If nothing is specified, the path
     :file:`extensionName/Resources/Private/Partials` is used. All partials that are
     necessary for this extension should reside in this folder.
 
-``view.pluginNamespace``
+`view.pluginNamespace`
     This can be used to specify an alternative namespace for the plugin.
     Use this to shorten the Extbase default plugin namespace or to access
     arguments from other extensions by setting this option to their namespace.
 
-``view.templateRootPath``
+`view.templateRootPath`
     This can be used to specify the root path for all fluid templates in this
     extension. If nothing is specified, the path
     :file:`extensionName/Resources/Private/Templates` is used. All layouts that are necessary
@@ -301,8 +302,8 @@ _LOCAL_LANG
 -----------
 
 Under this key you can modify localized strings for this extension.
-If you specify for example ``plugin.tx_blogexample._LOCAL_LANG.default.read_more =
-More>>`` then the standard translation for the key read_more is overwritten by the
+If you specify for example `plugin.tx_blogexample._LOCAL_LANG.default.read_more =
+More>>` then the standard translation for the key read_more is overwritten by the
 string *More>>*.
 
 .. _class_hierarchy:
@@ -339,32 +340,32 @@ ActionController API
 The action controller is usually the base class for your own controller. Below
 you see the most important properties of the action controller:
 
-``$actionMethodName``
+`$actionMethodName`
     Name of the executed action.
 
-``$argumentMappingResults``
+`$argumentMappingResults`
     Results of the argument mapping. Is used especially in the errorAction.
 
-``$defaultViewObjectName``
+`$defaultViewObjectName`
     Name of the default view, if no fluid-view or an action-specific view was found.
 
-``$errorMethodName``
+`$errorMethodName`
     Name of the action that is performed when generating the arguments of actions
     fail. Default is errorAction. In general, it is not sensible to change this.
 
-``$request``
+`$request`
     Request object of type :class:`\\TYPO3\\CMS\\Extbase\\Mvc\\RequestInterface`.
 
-``$response``
+`$response`
     Response object of type :class:`\\TYPO3\\CMS\\Extbase\\Mvc\\ResponseInterface`.
 
-``$settings``
+`$settings`
     Domain-specific extension settings from TypoScript (as array).
 
-``$view``
+`$view`
     The view used of type :class:`\\TYPO3\\CMS\\Extbase\\Mvc\\View\\ViewInterface`.
 
-``$viewObjectNamePattern``
+`$viewObjectNamePattern`
     If no fluid template is found for the current action, Extbase attempts to find a
     PHP-View-Class for the action. The naming scheme of the PHP-View-Class can be
     changed here. By default names are used according to the scheme
@@ -422,7 +423,7 @@ Most important API methods of action controller
 Actions
 -------
 
-All public methods that end in action (for example ``indexAction`` or ``showAction``),
+All public methods that end in action (for example `indexAction` or `showAction`),
 are automatically registered as actions of the controller.
 
 Many of these actions have parameters. These appear as annotations in the Doc-Comment-Block
@@ -445,7 +446,7 @@ of the specified method, as shown in Example B-3:
     public function newAction(\Ex\BlogExample\Domain\Model\Blog $newBlog = NULL)
     {
         $this->view->assign('newBlog', $newBlog);
-    );
+    )
 
 It is important to specify the full type in the *@param* annotation as this is used for the validation
 of the object. Note that not only simple data types such as String, Integer or Float can be validated,
@@ -455,8 +456,8 @@ In addition, on actions showing the forms used to create or edit domain View obj
 domain objects must be explicitly disabled - therefore the annotation *@dontvalidate* is necessary.
 
 Default values can, as usual in PHP, just be indicated in the method signature. In the above case,
-the default value of the parameter ``$newBlog`` is set to NULL. If an action returns NULL or nothing,
-then automatically ``$this->view->render()`` is called, and thus the view is rendered.
+the default value of the parameter `$newBlog` is set to NULL. If an action returns NULL or nothing,
+then automatically `$this->view->render()` is called, and thus the view is rendered.
 
 .. _class_hierarchy-define_initialization_code:
 
@@ -478,8 +479,8 @@ Catching validation errors with errorAction
 -------------------------------------------
 
 If an argument validation error has occurred, the method :code:`errorAction()` is called. There,
-in ``$this->argumentsMappingResults`` you have a list of occurred warnings and errors of the argument
-mappings available. This default ``errorAction`` refers back to the last sent form, if the referrer
+in `$this->argumentsMappingResults` you have a list of occurred warnings and errors of the argument
+mappings available. This default `errorAction` refers back to the last sent form, if the referrer
 was sent with it.
 
 Application domain of the extension
@@ -534,7 +535,7 @@ Each repository provides the following public methods:
 
 :code:`findByProperty($propertyValue)` and :code:`countByProperty($propertyValue)`
     Magic finder method. Finding all objects (or the number of them) for the property *property* having
-    a value of ``$propertyValue`` and returns them in an array, or the number as an integer value.
+    a value of `$propertyValue` and returns them in an array, or the number as an integer value.
 
 :code:`findOneByProperty($propertyValue)`
     Magic finder method. Finds the first object, for which the given property *property* has the value
@@ -571,8 +572,8 @@ to formulate a request:
         return $query->execute();
     }
 
-Create a ``Query`` object within the repository through ``$this->createQuery()``. You can give the query
-object a constraint using ``$query->matching($constraint)``. The following comparison operations for
+Create a ``Query`` object within the repository through `$this->createQuery()`. You can give the query
+object a constraint using `$query->matching($constraint)`. The following comparison operations for
 generating a single condition are available:
 
 :code:`$query->equals($propertyName, $operand, $caseSensitive);`
@@ -580,11 +581,11 @@ generating a single condition are available:
     In the case of strings you can specified additionally, whether the comparison is case-sensitive.
 
 :code:`$query->in($propertyName, $operand);`
-    Checks if the value of the property _$propertyName_ is present within the series of values in ``$operand``.
+    Checks if the value of the property _$propertyName_ is present within the series of values in `$operand`.
 
 :code:`$query->contains($propertyName, $operand);`
-    Checks whether the specified property ``$propertyName`` containing a collection has an element
-    ``$operand`` within that collection.
+    Checks whether the specified property `$propertyName` containing a collection has an element
+    `$operand` within that collection.
 
 :code:`$query->like($propertyName, $operand);`
     Comparison between the value of the property specified by $propertyName and a string $operand.
@@ -603,8 +604,8 @@ generating a single condition are available:
 :code:`$query->greaterThanOrEqual($propertyName, $operand);`
     Checks if the value of the property $propertyName is greater than or equal to the operand.
 
-Since 1.1 ``$propertyName`` is not necessarily only a simple property-name but also can be a "property path".
-    Example: ``$query->equals('categories.title', 'tools')`` searches for objects having a category titled
+Since 1.1 `$propertyName` is not necessarily only a simple property-name but also can be a "property path".
+    Example: `$query->equals('categories.title', 'tools')` searches for objects having a category titled
     "tools" assigned. If necessary, you can combine multiple conditions with boolean operations.
 
 :code:`$query->logicalAnd($constraint1, $constraint2);`
@@ -682,7 +683,7 @@ example:
         protected $title;
 
         // the class continues here
-    };
+    }
 
 In this code section, the validators for the $title attribute of the Blog object
 is defined. $title must be a text (ie, no HTML is allowed), and also the length
@@ -726,18 +727,18 @@ functionality in templates.
 The localization class has only one public static method called translate, which
 does all the translation. The method can be called like this:
 
-``\TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate($key, $extensionName, $arguments=NULL)``
+`\TYPO3\CMS\Extbase\Uility\LocalizationUtility::translate($key, $extensionName, $arguments=NULL)`
 
-``$key``
+`$key`
     The identifier to be translated. If then format *LLL:path:key* is given, then this
     identifier is used and the parameter $extensionName is ignored. Otherwise, the
     file :file:`Resources/Private/Language/locallang.xml` from the given extension is loaded
     and the resulting text for the given key in the current language returned.
 
-``$extensionName``
+`$extensionName`
     The extension name. It can be fetched from the request.
 
-``$arguments``
+`$arguments`
     Allows you to specify an array of arguments passed to the function vsprintf. Allows you to fill
     wildcards in localized strings with values.
 

--- a/Documentation/b-ExtbaseReference/Index.rst
+++ b/Documentation/b-ExtbaseReference/Index.rst
@@ -10,6 +10,8 @@ Extbase extensions.
 	Under http://typo3.org/go/extbasereferencesheet/ you find a useful
 	Cheat Sheet for Extbase and Fluid.
 
+.. _configuration_of_frontend_plugins:
+
 Configuration of frontend plugins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/Documentation/b-ExtbaseReference/Index.rst
+++ b/Documentation/b-ExtbaseReference/Index.rst
@@ -13,7 +13,7 @@ Extbase extensions.
 .. _configuration_of_frontend_plugins:
 
 Configuration of frontend plugins
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In classical TYPO3 extensions the front-end functionality is divided into
 several front-end Plugins. Normally each has a separate code base.
@@ -282,7 +282,7 @@ you should have a look at the controllers below.
 	the following section.
 
 ActionController API
-^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^
 
 The action controller is usually the base class for your own controller. Below
 you see the most important properties of the action controller:
@@ -363,7 +363,7 @@ Now follow the most important API methods of the action controller:
 
 
 Actions
-^^^^^^^^
+^^^^^^^
 
 All public methods that end in action (for example ``indexAction`` or ``showAction``),
 are automatically registered as actions of the controller.
@@ -403,7 +403,7 @@ the default value of the parameter ``$newBlog`` is set to NULL. If an action ret
 then automatically ``$this->view->render()`` is called, and thus the view is rendered.
 
 Define initialization code
----------------------------
+--------------------------
 
 Sometimes it is necessary to execute code before calling an action. This is the case, for example,
 if complex arguments must be registered or required classes must be instantiated.
@@ -415,7 +415,7 @@ Here you can perform action specific initializations (e.g. :code:`initializeShow
 Only then the action itself is called.
 
 Catching validation errors with errorAction
---------------------------------------------
+-------------------------------------------
 
 If an argument validation error has occurred, the method :code:`errorAction()` is called. There,
 in ``$this->argumentsMappingResults`` you have a list of occurred warnings and errors of the argument
@@ -423,7 +423,7 @@ mappings available. This default ``errorAction`` refers back to the last sent fo
 was sent with it.
 
 Application domain of the extension
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The domain of the extension is always located below :file:`Classes/Domain`. This folder is structured
 as follows:
@@ -438,7 +438,7 @@ as follows:
 	Contains specific validators for the domain model.
 
 Domain model
--------------
+------------
 
 All classes of the domain model must inherit from one of the following two classes:
 
@@ -450,7 +450,7 @@ All classes of the domain model must inherit from one of the following two class
 	ValueObjects are immutable.
 
 Repositories
--------------
+------------
 
 All repositories inherit from :class:`Tx_Extbase_Persistence_Repository`. A repository is always
 resposible for precisely one type of domain object. The naming of the repositories is important:
@@ -582,7 +582,7 @@ necessary. Validators are often used in conjunction with domain objects and
 controller actions.
 
 Validating properties of the domain model
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can define simple validation rules in the domain model by annotation. For
 this, you use the annotation *@validate* with properties of the object. A brief
@@ -613,7 +613,7 @@ If complex validation rules are necessary (for example, multiple fields to be
 checked for equality), you must implement your own validator.
 
 Validation of controller arguments
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Each controller argument is validated by the following rules: If the argument
 has a simple type (string, integer, etc.), this type is checked. If the argument


### PR DESCRIPTION
I recommend to ignore white spaces as all files I've worked on are reindented with 4 spaces instead of tabs to follow PSR2 as the TYPO3.CMS Core.

Only the Extbase reference was updated. All other files were modified to get more labels for linking from the reference.

i've tried to make most changes topic related in there own commits. Just the last commit is huge as it's the main work on the reference. So perhaps it's easier to proof the PR by checking each commit.