### PR TITLE
Minor grammatical fixes

### DIFF
--- a/Documentation/1-Installation/3-configuring-your-ide.rst
+++ b/Documentation/1-Installation/3-configuring-your-ide.rst
@@ -4,8 +4,8 @@ Configuring your IDE
 ====================
 
 An Extension based on Extbase consists of many files, so it is helpful
-to use a PHP development environment (IDE) instead of a simple editor. Among
-syntax highlighting an IDE offers code completion in first place and a
+to use a PHP development environment (IDE) instead of a simple editor. Along with
+syntax highlighting, an IDE offers code completion and a
 direct view of the code documentation. Some development environments also
 have an integrated debugger, which makes detecting errors easier and faster.
 To give you an example we'll show you how to set up NetBeans and Eclipse for


### PR DESCRIPTION
If you don't wish to remove "in first place", another option would be to change "in first place and" to "in the first place, as well as".