### PR TITLE
Adjusted a CREATE STATEMENT and PHP-Code

### DIFF
--- a/Documentation/4-FirstExtension/4-make-products-persistent.rst
+++ b/Documentation/4-FirstExtension/4-make-products-persistent.rst
@@ -33,7 +33,7 @@ command in the file :file:`EXT:inventory/ext_tables.sql`:
 		quantity int(11) DEFAULT '0' NOT NULL,
 
 		PRIMARY KEY (uid),
-		KEY parent (pid),
+		KEY parent (pid)
 	);
 
 This SQL command designs a new table with the corresponding columns.
@@ -141,7 +141,7 @@ in our case::
 	<?php
 	class Tx_Inventory_Domain_Repository_ProductRepository
 	extends Tx_Extbase_Persistence_Repository {}
-	?>
+	
 
 Our ``ProductRepository`` must be derived by
 ``Tx_Extbase_Persistence_Repository`` and inherits by this all methods. It can

--- a/Documentation/4-FirstExtension/4-make-products-persistent.rst
+++ b/Documentation/4-FirstExtension/4-make-products-persistent.rst
@@ -109,7 +109,7 @@ appropriate arranged.
 		'0' => array('showitem' => 'name, description, quantity')
 	)
 	);
-	?>
+	
 
 After we installed the Extension, we can create our first products in the
 backend. Like shown in image 4-2, we create a sys folder that takes the products (see 1 in figure 4-2).


### PR DESCRIPTION
The CREATE STATEMENT for the relation tx_inventory_domain_model_product ends with KEY PARENT (pid), ); The last comma must not be there.

Despite that it is a good habit not to close the PHP.tag unless it is necessary to avoid the possible bug "headers already sent".