### PR TITLE
Correct object accessor spellings in Fluid example

### DIFF
--- a/Documentation/8-Fluid/1-basic-concepts.rst
+++ b/Documentation/8-Fluid/1-basic-concepts.rst
@@ -53,9 +53,9 @@ Now we can insert the string »Webdesign-Blog« into the
 template with the Object Accessor ``{blogTitle}``. Let us take a
 look at the associated template::
 
-    <h1>{blog.Title}</h1>
+    <h1>{blogTitle}</h1>
 
-    <f:for each="{blogPost}" as="post">
+    <f:for each="{blogPosts}" as="post">
         <b>{post.title}</b><br />
     </f:for>
 


### PR DESCRIPTION
PostController function indexAction assigns 'blogTitle' and 'blogPosts', but its Fluid template example misspells both object accessors as 'blog.Title' and 'blogPost', creating confusion. The following narrative uses 'blogTitle' explicitly.