### PR TITLE
[TASK] Update Namespaces and ClassNames

### DIFF
--- a/Documentation/1-Installation/6-more-helpful-extensions.rst
+++ b/Documentation/1-Installation/6-more-helpful-extensions.rst
@@ -32,7 +32,7 @@ devlog
 
 The extension *devlog* (available in TER) can used for logging the program sequence. All log messages are clearly structured in the backend module. This extension is especially helpful if no debug output is allowed in the frontend, eq. live systems.
 
-To log data you can use the method *t3lib_div::devlog($message, $extensionKey, $severity, $data)*, where *$message* is the message which should be logged, *$extensionKey* is the extension key of the running extension, *$severity* is a number between -1 and 3 which specifies the severity of an error, and *$data* is an optional array which can also be logged.
+To log data you can use the method *GeneralUtility::devlog($message, $extensionKey, $severity, $data)*, where *$message* is the message which should be logged, *$extensionKey* is the extension key of the running extension, *$severity* is a number between -1 and 3 which specifies the severity of an error, and *$data* is an optional array which can also be logged.
 
 More information can be found in the online documentation of the extension *devlog* in TER.
 

--- a/Documentation/2-BasicPrinciples/1-Object-oriented Programming-in-PHP.rst
+++ b/Documentation/2-BasicPrinciples/1-Object-oriented Programming-in-PHP.rst
@@ -589,7 +589,7 @@ more than one instance of the shipyard object:
 
 In order to have the singletons correctly created you have to use
 the static TYPO3 Method
-:class:`t3lib_div::makeInstance()`. This method gives back
+:class:`GeneralUtility::makeInstance()`. This method gives back
 - as seen in the example above - always the same object, if you request
 a singleton.
 

--- a/Documentation/2-BasicPrinciples/2-Domain-Driven-Design.rst
+++ b/Documentation/2-BasicPrinciples/2-Domain-Driven-Design.rst
@@ -445,7 +445,7 @@ always built a consistent object.
 .. note::
 
 	In TYPO3 you can not generate classes with the new operator, but with
-	t3lib_div::makeInstance (className). In the example above, we wanted to
+	GeneralUtility::makeInstance (className). In the example above, we wanted to
 	concentrate on the essentials, so we have used new there.
 
 Reconstitute objects with repositories

--- a/Documentation/2-BasicPrinciples/4-Test-Driven-Development.rst
+++ b/Documentation/2-BasicPrinciples/4-Test-Driven-Development.rst
@@ -123,18 +123,18 @@ Tests/Unit/Domain/Model/CustomerTest.php. Now we create a minimal testcase with 
 //code
 
 All our testcasses are named after the same namescheme like normal classes and
-they must be extended with Tx_Extbase_BaseTestCase. One testclass can contain
-many testmethods. These have to be public and have to contain the annotation
-@test in their PHPDOC-Block, so they can be performed. Please keep in mind that
-the name of the testmethod should make clear which expectations the test should
-fullfill. Now we can run the test for the first time. Therefore go to the
-TYPO3-Backend to the modul PHPUnit which is to find under the Admin Tools. Then
-you can choose your extension and click on Run all tests. Now you should, like
-it is shown in the figure 2-9, see a (yellow) bar and the Error message Not yet
-implemented. Because you will work much with the PHPUnit Environment, you should
-familiarize yourself with this. Try to run the test for extbase and fluid and
-also try the different Display options. For example you can let show you all
-tests or only the failed tests.
+they must be extended with \TYPO3\CMS\Core\Tests\BaseTestCase. One testclass
+can contain many testmethods. These have to be public and have to contain the
+annotation @test in their PHPDOC-Block, so they can be performed. Please keep
+in mind that the name of the testmethod should make clear which expectations
+the test should fullfill. Now we can run the test for the first time. Therefore
+go to the TYPO3-Backend to the modul PHPUnit which is to find under the Admin
+Tools. Then you can choose your extension and click on Run all tests. Now you
+should, like it is shown in the figure 2-9, see a (yellow) bar and the Error
+message Not yet implemented. Because you will work much with the PHPUnit
+Environment, you should familiarize yourself with this. Try to run the test
+for extbase and fluid and also try the different Display options. For example
+you can let show you all tests or only the failed tests.
 
 
 Now we know that our testcase is running, we can write our first usefull

--- a/Documentation/3-BlogExample/11-Alternative-route-creating-a-new-posting.rst
+++ b/Documentation/3-BlogExample/11-Alternative-route-creating-a-new-posting.rst
@@ -45,12 +45,12 @@ Lets take a look at the called method ``newAction()``:
 	/**
 	 * Displays a form for creating a new post
 	 *
-	 * @param Tx_BlogExample_Domain_Model_Blog $blog The blog the post belongs to
-	 * @param Tx_BlogExample_Domain_Model_Post $newPost An invalid new post object passed by a rejected createAction()
+	 * @param \MyVendor\BlogExample\Domain\Model\Blog $blog The blog the post belongs to
+	 * @param \MyVendor\BlogExample\Domain\Model\Post $newPost An invalid new post object passed by a rejected createAction()
 	 * @return string An HTML form for creating a new post
 	 * @dontvalidate $newPost
 	 */
-	public function newAction(Tx_BlogExample_Domain_Model_Blog $blog, Tx_BlogExample_Domain_Model_Post $newPost = NULL) {
+	public function newAction(\MyVendor\BlogExample\Domain\Model\Blog $blog, \MyVendor\BlogExample\Domain\Model\Post $newPost = NULL) {
 		$this->view->assign('authors', $this->personRepository->findAll();
 		$this->view->assign('blog', $blog);
 		$this->view->assign('newPost', $newPost);
@@ -66,8 +66,8 @@ parameters before an action is called. The controller delegates this  to an
 instance of the class :class:`PropertyManager`, that has mainly two functions: it
 converts the parameter from the call (from our link) into the target object and
 checks if it is valid. The target for the parameter ``$blog`` is an instance of the
-class :class:`Tx_BlogExample_Domain_Model_Blog`, for the parameter ``$newPost`` it
-is an instance of the class :class:`Tx_BlogExample_Domian_Model_Post`.
+class :class:`\MyVendor\BlogExample\Domain\Model\Blog`, for the parameter ``$newPost`` it
+is an instance of the class :class:`\MyVendor\BlogExample\Domain\Model\Post`.
 
 How does Extbase know what the target of the conversion is? It takes this
 information from the information above the argument. If there is nothing declared
@@ -76,7 +76,7 @@ the line:
 
 ::
 
-	* @param Tx_BlogExample_Domain_Model_Blog $blog The blog the post belongs to
+	* @param \MyVendor\BlogExample\Domain\Model\Blog $blog The blog the post belongs to
 
 The link is created with the name of the argument ``$blog``.
 In this way the link between the request parameter and the ``newAction()`` is resolved.
@@ -86,7 +86,7 @@ The link parameter::
 
 is assigned to the parameter::
 
-	Tx_BlogExample_Domain_Model_Blog $blog
+	\MyVendor\BlogExample\Domain\Model\Blog $blog
 
 of the ``newAction()`` with the name "blog". With the help of the UID 6 the
 corresponding blog object can be identified, reconstructed and given to the
@@ -176,12 +176,12 @@ Here you will see the stripped-down method:
 	/**
 	 * Creates a new post
 	 *
-	 * @param Tx_BlogExample_Domain_Model_Blog $blog The blog the post belongs to
-	 * @param Tx_BlogExample_Domain_Model_Post $newPost A fresh Post object which has not yet been persisted
+	 * @param \MyVendor\BlogExample\Domain\Model\Blog $blog The blog the post belongs to
+	 * @param \MyVendor\BlogExample\Domain\Model\Post $newPost A fresh Post object which has not yet been persisted
 	 * @return void
 	 */
-	public function createAction(Tx_BlogExample_Domain_Model_Blog $blog,
-		  Tx_BlogExample_Domain_Model_Post $newPost) {
+	public function createAction(\MyVendor\BlogExample\Domain\Model\Blog $blog,
+		  \MyVendor\BlogExample\Domain\Model\Post $newPost) {
 		$blog->addPost($newPost);
 		$this->redirect('index', NULL, NULL, array('blog' => $blog));
 	}

--- a/Documentation/3-BlogExample/12-automatic-persistence-of-the-domain-logic.rst
+++ b/Documentation/3-BlogExample/12-automatic-persistence-of-the-domain-logic.rst
@@ -56,7 +56,7 @@ property values.
 	How does extbase know that a property value has changed? Every
 	object of the domain of your extension (domain object) must enhance a
 	defined class of extbase. For the blog class this is
-	``Tx_Extbase_DomainObject_AbstractEntity``. Inside this parent
+	``\TYPO3\CMS\Extbase\DomainObject\AbstractEntity``. Inside this parent
 	class a property ``$_cleanProperties`` is defined. This property
 	is directly, after the recontruction of the object (restored from the
 	database), initialized with the unchanged property values with a call of
@@ -73,7 +73,7 @@ property values.
 	attractive to do that. In FLOW3 the "observation" of the objects is solced
 	in an other way and it is not applicable to enhance a parent class of the
 	framework. The declaration ``extends
-	Tx_Extbase_DomainObject_AbstractEntity`` can simply be removed when
+	\TYPO3\CMS\Extbase\DomainObject\AbstractEntity`` can simply be removed when
 	you port your extension to TYPO3 v5.
 
 In our example the backend find the new post while it iterates through

--- a/Documentation/3-BlogExample/3-calling-the-extension.rst
+++ b/Documentation/3-BlogExample/3-calling-the-extension.rst
@@ -50,7 +50,7 @@ The class :class:`BlogController` can be found in the
 file
 :file:`EXT:blog_example/Classes/Controller/BlogController.php`.
 The complete name of the controller is
-:class:`Tx_BlogExample_Controller_BlogController`. At first
+:class:`\MyVendor\BlogExample\Controller\BlogController`. At first
 this might seem long-winded but the syntax follows a very strict convention
 (please see box "Be careful, conventions!").
 

--- a/Documentation/3-BlogExample/4-and-action.rst
+++ b/Documentation/3-BlogExample/4-and-action.rst
@@ -15,36 +15,39 @@ short methods, which are responsible for the control of a single action, the
 so called `Actions`. Let's have a deeper look at a
 shortened version of the :class:`BlogController`::
 
-    class Tx_BlogExample_Controller_BlogController
-          extends Tx_Extbase_MVC_Controller_ActionController {
+    <?php
+    namespace \MyVendor\BlogExample\Controller;
+
+    class BlogController
+          extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController {
 
         public function indexAction() {
             $this->view->assign('blogs', $this->blogRepository->findAll());
         }
 
-        public function newAction(Tx_BlogExample_Domain_Model_Blog $newBlog = NULL) {
+        public function newAction(\MyVendor\BlogExample\Domain\Model\Blog $newBlog = NULL) {
             $this->view->assign('newBlog', $newBlog);
             $this->view->assign('administrators', $this->administratorRepository->findAll());
         }
 
-        public function createAction(Tx_BlogExample_Domain_Model_Blog $newBlog) {
+        public function createAction(\MyVendor\BlogExample\Domain\Model\Blog $newBlog) {
             $this->blogRepository->add($newBlog);
             $this->redirect('index');
         }
 
-        public function editAction(Tx_BlogExample_Domain_Model_Blog $blog) {
+        public function editAction(\MyVendor\BlogExample\Domain\Model\Blog $blog) {
             $this->view->assign('blog', $blog);
             $this->view->assign('administrators', $this->administratorRepository->findAll());
         }
 
-        public function updateAction(Tx_BlogExample_Domain_Model_Blog $blog) {
+        public function updateAction(\MyVendor\BlogExample\Domain\Model\Blog $blog) {
             $this->blogRepository->update($blog);
             // this does currently not work, use $this->blogRepository->add($blog); instead
             // see issue: https://forge.typo3.org/issues/76876
             $this->redirect('index');
         }
 
-        public function deleteAction(Tx_BlogExample_Domain_Model_Blog $blog) {
+        public function deleteAction(\MyVendor\BlogExample\Domain\Model\Blog $blog) {
             $this->blogRepository->remove($blog);
             $this->redirect('index');
         }
@@ -85,12 +88,14 @@ change of an existing blog. The job of the
 From the request the controller can extract which action has to be
 called. The call is happening without the need to write another line of code
 in the BlogController. This does
-:class:`Tx_Extbase_MVC_Controller_ActionController`. The
+:class:`\TYPO3\CMS\Extbase\Mvc\Controller\ActionController`. The
 BlogController "inherits" all methods from it, by deriving it form this
 class::
+    <?php
+    namespace \MyVendor\BlogExample\Controller;
 
-    class Tx_BlogExample_Controller_BlogController extends
-        Tx_Extbase_MVC_Controller_ActionController {...}
+    class BlogController extends
+        \TYPO3\CMS\Extbase\Mvc\Controller\ActionController {...}
 
 At first call of the plugin without additional information the request
 will get a standard action; in our case the
@@ -99,7 +104,7 @@ will get a standard action; in our case the
 (as shown above), which looks more detailled like this::
 
     public function indexAction() {
-        $blogRepository = t3lib_div::makeInstance('Tx_BlogExample_Domain_Repository_BlogRepository');
+        $blogRepository = GeneralUtility::makeInstance('\MyVendor\BlogExample\Domain\Repository\BlogRepository');
         $allAvailableBlogs = $blogRepository->findAll();
         $this->view->assign('blogs', $allAvailableBlogs);
         $content = $this->view->render();

--- a/Documentation/3-BlogExample/5-Get-Blog-from-the-Repository.rst
+++ b/Documentation/3-BlogExample/5-Get-Blog-from-the-Repository.rst
@@ -7,14 +7,15 @@ Lets take a look into the ``BlogRepository`` and travel into the inner core of
 our little action island.
 
 ::
+	<?php
+	namespace \MyVendor\BlogExample\Domain\Repository;
 
-	class Tx_BlogExample_Domain_Repository_BlogRepository
-		extends Tx_Extbase_Persistence_Repository {
+	class BlogRepository extends \TYPO3\CMS\Extbase\Persistence\Repository {
 	}
 
 The code is not shortened. The ``BlogRepository`` simply does not have any own
 code since all methods which are used very often are already implemented in the
-parent class :class:`Tx_Extbase_Persistence_Repository`. These functions are also
+parent class :class:`\TYPO3\CMS\Extbase\Persistence\Repository`. These functions are also
 available in all child classes. We call the method ``findAll()``, to retrieve all
 blog objects.
 

--- a/Documentation/3-BlogExample/6-An-excursion-to-the-database.rst
+++ b/Documentation/3-BlogExample/6-An-excursion-to-the-database.rst
@@ -11,7 +11,7 @@ that extbase will take care about this you can skip this trip (chapter), or come
 back later. You will receive a free travel coupon then.
 
 The ``BlogRepository`` creates a ``Query`` object with the class
-:class:`Tx_Extbase_Persistence_Query`, which is specialised for ``Blog`` objects, and
+:class:`\TYPO3\CMS\Extbase\Persistence\Generic\Query`, which is specialised for ``Blog`` objects, and
 executes the query (``$query->execute()``). The ``Query`` object is mostly abstracted
 from the physical storage - normally a relational database. It does not contain
 any information of how something is searched for it only contains what is

--- a/Documentation/3-BlogExample/7-Paths-on-the-Data-Map.rst
+++ b/Documentation/3-BlogExample/7-Paths-on-the-Data-Map.rst
@@ -23,13 +23,16 @@ definitions (or *properties*). Let's for example look at the definition of the
 property *posts* within the ``Blog`` class. You can find this in the file
 :file:`EXT:blog_example/Classes/Domain/Model/blog.php`. ::
 
-    class Tx_BlogExample_Domain_Model_Blog extends Tx_Extbase_DomainObject_AbstractEntity {
+    <?php
+    namespace \MyVendor\BlogExample\Domain\Model;
+
+    class Blog extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity {
         ...
 
         /**
          * The posts of this blog
          *
-         * @var Tx_Extbase_Persistence_ObjectStorage<Tx_BlogExample_Domain_Model_post>
+         * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\MyVendor\BlogExample\Domain\Model\post>
          *
          */
         protected $posts;
@@ -41,15 +44,15 @@ property *posts* within the ``Blog`` class. You can find this in the file
 The property ``$posts`` contains within the PHP comment above some so called
 annotations which start with the @ character. The annotation::
 
-    @var Tx_Extbase_Persistence_ObjectStorage<Tx_BlogExample_Domain_Model_Post>
+    @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\MyVendor\BlogExample\Domain\Model\Post>
 
 
 tells the ``DataMapper`` to create an ``ObjectStorage`` there and fill it with the
-``Post`` objects of the class :class:`Tx_BlogExample_Domain_Model_Post`.
+``Post`` objects of the class :class:`\MyVendor\BlogExample\Domain\Model\Post`.
 
 .. note::
 
-    The :class:`Tx_Extbase_Persistence_ObjectStorage` is a class of Extbase. This
+    The :class:`\TYPO3\CMS\Extbase\Persistence\ObjectStorage` is a class of Extbase. This
     class takes objects and ensures that an instance is unique within the
     ``ObjectStorage``. Objects within the ``ObjectStorage`` can be accessed by the
     methods ``attach()``, ``detach()`` and ``contains()`` amongst others. The
@@ -74,7 +77,7 @@ PHP-type will look like this::
 It is also possible to enter a class as type::
 
     /**
-     * @var Tx_BlogExample_Domain_Model_Author
+     * @var \MyVendor\BlogExample\Domain\Model\Author
      */
     protected $author;
 
@@ -83,7 +86,7 @@ Properties which should be bound to multiple child objects require the class
 name of the child elements in angle brackets::
 
     /**
-     * @var Tx_Extbase_Persistence_ObjectStorage<Tx_BlogExample_Domain_model_Tags>
+     * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\MyVendor\BlogExample\Domain\Model\Tags>
      */
     protected $tags;
 

--- a/Documentation/3-BlogExample/8-Back-in-the-controller.rst
+++ b/Documentation/3-BlogExample/8-Back-in-the-controller.rst
@@ -7,7 +7,7 @@ You get the ready ``Blog`` objects delivered in an array. "Ready" means in this
 context, that every ``Blog`` object already has all it's ``Post`` objects and their
 ``Comment`` and ``Tag`` objects.
 
-These blogs are delivered to the object, which is responsible for the output for 
+These blogs are delivered to the object, which is responsible for the output for
 further processing: the so called *View*. If we make no own choice, like in our
 example, the TemplateView of Fluid is automatically available under the class
 variable ``$this->view``.
@@ -29,8 +29,8 @@ instantiated:
 ::
 
 	public function initializeAction() {
-		$this->blogRepository = t3lib_div::makeInstance('Tx_BlogExample_Domain_Repository_BlogRepository');
-		$this->administratorRepository = t3lib_div::makeInstance('Tx_BlogExample_Domain_Repository_AdministratorRepository');
+		$this->blogRepository = GeneralUtility::makeInstance('\MyVendor\BlogExample\Domain\Repository\BlogRepository');
+		$this->administratorRepository = GeneralUtility::makeInstance('\MyVendor\BlogExample\Domain\Repository\AdministratorRepository');
 	}
 
 This approach offers no performance gain (rather a negligible disadvantage), but

--- a/Documentation/3-BlogExample/9-Rendering-the-output-with-fluid.rst
+++ b/Documentation/3-BlogExample/9-Rendering-the-output-with-fluid.rst
@@ -114,7 +114,7 @@ Parsing the point goes recursively. That means Fluid can parse a string
     Cross Site Scripting-Attacks (XSS).
 
 As soon as Fluid is done with the whole template the result is appended to the
-``Response`` object. This is done in the :class:`Tx_Extbase_MVC_Controller_ActionController`
+``Response`` object. This is done in the :class:`\TYPO3\CMS\Extbase\Mvc\Controller\ActionController`
 by the call ``$this->response->appendContent($this->view->render())``.
 
 Our journey slowly comes to an end. The *Request* is been fully answered by a

--- a/Documentation/4-FirstExtension/2-create-folder-structure-and-configuration-files.rst
+++ b/Documentation/4-FirstExtension/2-create-folder-structure-and-configuration-files.rst
@@ -83,7 +83,7 @@ appropriate, also a certain version).
 |	 ``'version' => '0.0.0',``
 |	 ``'constraints' => array(``
 |	  ``'depends' => array(``
-|		``'typo3' => '4.3.0-4.3.99',``
+|		``'typo3' => '7.6.0-7.6.99',``
 |		**'extbase' => '1.0.0-0.0.0',**
 |		**'fluid' => '1.0.0-0.0.0',**
 |	  ``)``

--- a/Documentation/4-FirstExtension/3-create-the-domain-model.rst
+++ b/Documentation/4-FirstExtension/3-create-the-domain-model.rst
@@ -6,7 +6,7 @@ Create The Domain Model
 The domain of our first extension is very simple. The essential
 concept of our domain is the "product". All the important properties for us
 of a product and its "behavior" are defined in a class with the name
-:class:`Tx_Inventory_Domain_Model_Product`. The code of this
+:class:`\MyVendor\Inventory\Domain\Model\Product`. The code of this
 class is stored in a file with the name :file:`Product.php`.
 The name of the file arises through supplements of :file:`.php`
 at the last word, to count after the last underscore, of the class name.
@@ -17,18 +17,22 @@ This class file is stored in the folder
 
     The labels of the classes always must reflect the folder structure.
     For example extbase expects the class
-    :class:`Tx_MyExtension_FirstFolder_SecondFolder_File` in the
+    :class:`\MyVendor\MyExtension\FirstFolder\SecondFolder\File` in the
     folder
     :file:`my_extension/Classes/FirstFolder/SecondFolder/File.php`.
     Pay attention to the corresponding upper case of the folder names.
 
 Below we have a view into this file, note that the class
-:class:`Tx_Inventory_Domain_Model_Product` must be derivated
+:class:`\MyVendor\Inventory\Domain\Model\Product` must be derivated
 from the extbase class
-:class:`Tx_Extbase_DomainObject_AbstractEntity`. ::
+:class:`\TYPO3\CMS\Extbase\DomainObject\AbstractEntity`. ::
 
     <?php
-    class Tx_Inventory_Domain_Model_Product extends Tx_Extbase_DomainObject_AbstractEntity {
+    namespace \MyVendor\Inventory\Domain\Model\;
+
+    use \TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+
+    class Product extends AbstractEntity {
     /**
      * @var string
      **/

--- a/Documentation/4-FirstExtension/4-make-products-persistent.rst
+++ b/Documentation/4-FirstExtension/4-make-products-persistent.rst
@@ -6,7 +6,7 @@ Make Products Persistent
 ========================
 
 From the class
-:class:`Tx_Inventory_Domain_Model_Product`, now we already can
+:class:`\MyVendor\Inventory\Domain\Model\Product`, now we already can
 generate instances – therefore concrete products with individual properties
 – at script run time. These are available however only in volatile form in
 the memory and are deleted by PHP after the page was produced completely by TYPO3.
@@ -109,7 +109,7 @@ appropriate arranged.
 		'0' => array('showitem' => 'name, description, quantity')
 	)
 	);
-	
+
 
 After we installed the Extension, we can create our first products in the
 backend. Like shown in image 4-2, we create a sys folder that takes the products (see 1 in figure 4-2).
@@ -133,18 +133,21 @@ world, is completely designed with this.
 
 In order to access the objects created in the backend, we create
 a Repository for the products. The
-``Tx_Inventory_Domain_Repository_ProductRepository`` is an
+``\MyVendor\Inventory\Domain\Repository\ProductRepository`` is an
 object, in that the products are discarded. We can request a Repository to find all (or
 certain) products and deliver it to us. The Repository class is very short
 in our case::
 
 	<?php
-	class Tx_Inventory_Domain_Repository_ProductRepository
-	extends Tx_Extbase_Persistence_Repository {}
-	
+	namespace \MyVendor\Inventory\Domain\Repository\;
+
+	use \TYPO3\CMS\Extbase\Persistence\Repository;
+
+	class ProductRepository extends Repository {}
+
 
 Our ``ProductRepository`` must be derived by
-``Tx_Extbase_Persistence_Repository`` and inherits by this all methods. It can
+``\TYPO3\CMS\Extbase\Persistence\Repository`` and inherits by this all methods. It can
 remain empty therefore in our simple example. We put the class file
 :file:`ProductRepository.php` into the directory :file:`EXT:inventory/Classes/Domain/Repository/`.
 

--- a/Documentation/4-FirstExtension/5-controlling-the-flow.rst
+++ b/Documentation/4-FirstExtension/5-controlling-the-flow.rst
@@ -5,7 +5,8 @@ Controlling The Flow
 
 The inventory created in the backend should be shown as a list in the frontend now.
 The creation of the HTML code out of the product objects to be shown is done by the *view*.
-Extbase uses the class :class:`Tx_Fluid_View_TemplateView` of the extension Fluid as default for the view.
+Extbase uses the class :class:`\TYPO3\CMS\Fluid\View\TemplateView` of the extension
+Fluid as default for the view.
 
 The connection between the *model* and the *view* is the *controller*. It controls the
 sequences inside the extension and is responsible for the ``list`` action in our case.
@@ -13,43 +14,47 @@ This includes locating the products which are to be shown, as well as transmissi
 selected products to the responsible view.
 
 The class name of the controller must end with ``Controller``. Because our controller controls
-the display of the inventory we call it ``Tx_Inventory_Controller_InventoryController``.
+the display of the inventory we call it ``\MyVendor\Inventory\Controller\InventoryController``.
 
 .. tip::
 
     When naming a controller you are free inside the described frame. We advise to name a
     controller by what he "controls". In big projects these are specially the aggregate root
     objects (see section "aggregates" in chapter 2). For this we had also named our controller
-    ``Tx_Inventory_Controller_ProductController``.
+    ``MyVendor\Inventory\Controller\ProductController``.
 
 In our simple example the controller looks like this:
 
 ::
 
     <?php
-    class Tx_Inventory_Controller_InventoryController
-          extends Tx_Extbase_MVC_Controller_ActionController {
+    namespace \MyVendor\Inventory\Controller\;
+    use \TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+    use \TYPO3\CMS\Core\Utility\GeneralUtility;
+    use \MyVendor\Inventory\Domain\Model\Repository\ProductRepository;
+
+    class InventoryController extends ActionController {
 
         public function listAction() {
-            $productRepository = t3lib_div::makeInstance('Tx_Inventory_Domain_Repository_ProductRepository');
+            $productRepository = GeneralUtility::makeInstance(ProductRepository::class);
             $products = $productRepository->findAll();
             $this->view->assign('products', $products);
         }
     }
     ?>
 
-Our ``Tx_Inventory_Controller_InventoryController`` must be derived from the
-``Tx_Extbase_MVC_Controller_ActionController``. It contains only the method ``findAll()``.
+Our ``\MyVendor\Inventory\Controller\InventoryController`` must be derived from the
+``\MyVendor\Extbase\MVC\Controller\ActionController``. It contains only the method ``findAll()``.
 Extbase identifies all methods that ends with ``Action`` as actions - so as little plan of procedures.
 
 In the first line of the ``listAction()`` the ``ProductRepository`` is instanced. The products to be
 shown we get by the method ``findAll()`` of the repository. This method is implemented in the class
-:class:`Tx_Extbase_Persistence_Repository`. Which methods are also still for disposition you can
+:class:`\TYPO3\CMS\Extbase\Persistence\Repository`. Which methods are also still for disposition you can
 read in chapter 6.
 
 .. tip::
 
-    Take care about using the framework method ``t3lib_div::makeInstance()`` of TYPO3 instead of the
+    Take care about using the framework method ``GeneralUtility::makeInstance()`` of TYPO3 instead of the
     keyword *new* to create new instances of the repository. Background for familiar folks: The repository
     is a so called *Singleton* and is marked accordingly for that. The method ``makeInstance()``
     recognize the singleton by means of the identification mark and returns - after the first creation -

--- a/Documentation/4-FirstExtension/6-adding-the-template.rst
+++ b/Documentation/4-FirstExtension/6-adding-the-template.rst
@@ -7,7 +7,7 @@ In Extbase frontend templates are created in a subdirectory of
 :file:`EXT:inventory/Resources/Private/Templates` - if not configured otherwise.
 The name of the subdirectory results in the last part of the controller
 class name without the ``Controller`` suffix.
-So the class name :class:`Tx_Inventory_Controller_InventoryController` results in the
+So the class name :class:`\MyVendor\Inventory\Controller\InventoryController` results in the
 directory name *inventory*.
 
 Below the directory *Inventory* we create the file with the HTML template. The name

--- a/Documentation/4-FirstExtension/7-configuring-the-plugin.rst
+++ b/Documentation/4-FirstExtension/7-configuring-the-plugin.rst
@@ -16,12 +16,11 @@ create in the top level of our extension directory.
     <?php
     if (!defined ('TYPO3_MODE')) die ('Access denied.');
 
-    Tx_Extbase_Utility_Extension::configurePlugin(
+    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
         $_EXTKEY,
         'List',
         array('Inventory' => 'list')
     );
-    ?>
 
 With the first line we prevent - like also in the file :file:`ext_tables.php` -
 of security reasons, that the PHP code can be called directly outside of TYPO3.
@@ -35,7 +34,7 @@ can execute. The array key is the name of the controller (without the suffix ``C
 and the array value is a comma separated list of all actions that are executable by the plugin.
 In our case this is the ``list`` action (also without the suffix ``Action``).
 Thus the array ``array('Inventory' -> 'list')`` allows to execute the method ``listAction()``
-in the ``Tx_Inventory_Controller_InventoryController`` by the plugin.
+in the ``\MyVendor\Inventory\Controller\InventoryController`` by the plugin.
 
 Per default all results of the actions are stored in the cache. If it is not desired for
 individual actions they can be specified by a fourth, optional argument.
@@ -54,11 +53,11 @@ of the content element *Plugin*. For this we insert the following line into the 
 
 ::
 
-    Tx_Extbase_Utility_Extension::registerPlugin(
+    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
         $_EXTKEY,
         'List',
         'The Inventory List'
-        );
+    );
 
 The first argument is like the method ``configurePlugin()`` again the extension key
 and the second is the name of the plugin. The third argument is an arbitrary, not to long,

--- a/Documentation/5-Domain/2-implementing-the-domain-model.rst
+++ b/Documentation/5-Domain/2-implementing-the-domain-model.rst
@@ -36,18 +36,18 @@ rename it according to the last part of the class name: Organization.php.
 	development and skip the class in a train. We have cautioned, however.
 
 First, we create the corresponding test class in the appropriate folder
-Tx_SjrOffers_Domain_Model_OrganizationTest EXT: sjr_offers/Tests /Domain
+\MyVendor\SjrOffers\Domain\Model\OrganizationTest EXT: sjr_offers/Tests /Domain
 /Model/. After that we write our test.
 
 ::
 
-	class OrganizationTest extends Tx_Extbase_BaseTestCase {
+	class OrganizationTest extends \TYPO3\CMS\Core\Tests\BaseTestCase {
 
 		/**
 		 * @test
 		 */
 		public function anInstanceOfTheOrganizationCanBeConstructed() {
-			$organization = new Tx_SjrOffers_Domain_Model_Organization('Name');
+			$organization = new \MyVendor\SjrOffers\Domain\Model\Organization('Name');
 			$this->assertEquals('Name', $organization->getName());
 		}
 	}
@@ -59,7 +59,7 @@ Tx_SjrOffers_Domain_Model_OrganizationTest EXT: sjr_offers/Tests /Domain
 	number of unit tests you will be able to remain focused.
 
 Note that our test class extends the class
-Tx_SjrOffers_Domain_Model_OrganizationTest Tx_Extbase_BaseTestCase of Extbase.
+\MyVendor\SjrOffers\Domain\Model\OrganizationTest \TYPO3\CMS\Core\Tests\BaseTestCase of Extbase.
 Among other things, this class initializes the autoloader, which makes the
 inclusion of the class files require_once() obsolete.
 
@@ -72,8 +72,10 @@ run because the appropriate class and its method get-Name() note yet exist. So
 we create first a minimum trunk of the class and its methods.
 
 ::
+	<?php
+	namespace \MyVendor\SjrOffers\Domain\Model;
 
-	class Tx_SjrOffers_Domain_Model_Organization {
+	class Organization {
 		public function getName() {
 		}
 	}
@@ -88,7 +90,10 @@ Only now we add just enough code that the test is successful:
 
 ::
 
-	class Tx_SjrOffers_Domain_Model_Organization extends Tx_Extbase_DomainObject_AbstractEntity{
+	<?php
+	namespace \MyVendor\SjrOffers\Domain\Model;
+
+	class Organization extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity{
 		/**
 		 * @var string The name of the organization
 		 */
@@ -127,7 +132,10 @@ String. Thereby our class looks like as follows:
 
 ::
 
-	class Tx_SjrOffers_Domain_Model_Organization {
+	<?php
+	namespace \MyVendor\SjrOffers\Domain\Model;
+
+	class Organization {
 
 		/**
 		 * @var string The name of the organization
@@ -147,11 +155,11 @@ String. Thereby our class looks like as follows:
 		}
 	}
 
-Now we implement step by step the class Tx_SjrOffers_Domain_Model_Organization –
+Now we implement step by step the class \MyVendor\SjrOffers\Domain\Model\Organization –
 always protected by our tests. Here we meet the requirement that there can be
 multiple contact persons. We want to keep ready in the capacity of contacts. So
-we set there a Tx_Extbase_Persistence_ObjectStorage, which later takes the
-instances of the class Tx_SjrOffers_Domain_Model_Person (or more precisely, the
+we set there a \TYPO3\CMS\Extbase\Persistence\ObjectStorage, which later takes the
+instances of the class \MyVendor\SjrOffers\Domain\Model\Person (or more precisely, the
 references to instances).
 
 But the test at first:
@@ -162,14 +170,14 @@ But the test at first:
 	 * @test
 	 */
 	public function theContactsAreInitializedAsEmptyObjectStorage() {
-		$organization = new Tx_SjrOffers_Domain_Model_Organization('Youth Organization');
-		$this->assertEquals('Tx_Extbase_Persistence_ObjectStorage',
+		$organization = new \MyVendor\SjrOffers\Domain\Model\Organization('Youth Organization');
+		$this->assertEquals('\TYPO3\CMS\Extbase\Persistence\ObjectStorage',
 		get_class($organization->getContacts()));
 		$this->assertEquals(0, count($organization->getContacts()));
 	}
 
 The contact person should be an instance of the class
-Tx_SjrOffers_Domain_Model_Person. Since this class does not exist, one could
+\MyVendor\SjrOffers\Domain\Model\Person. Since this class does not exist, one could
 make the next working to implement them. Thus we would probably get bogged down
 and jump from one class to the other. When writing unit tests can be upheld in
 so-called Mocks back. A mock is an object that can behave as if it were another.
@@ -184,37 +192,37 @@ example:
 	 * @test
 	 */
 	public function aContactCanBeAdded() {
-		$organization = new Tx_SjrOffers_Domain_Model_Organization('Youth Organization');
-		$mockContact = $this->getMock('Tx_SjrOffers_Domain_Model_Person');
+		$organization = new \MyVendor\SjrOffers\Domain\Model\Organization('Youth Organization');
+		$mockContact = $this->getMock('\MyVendor\SjrOffers\Domain\Model\Person');
 		$organization->addContact($mockContact);
 		$this->assertTrue($organization->getContacts()->contains($mockContact));
 	}
 
 The variable $mockContact contains the object, which behaves like an instance of
-the class Tx_SjrOffers_Domain_Model_Person. Because of this we can now use the
+the class \MyVendor\SjrOffers\Domain\Model\Person. Because of this we can now use the
 two methods addContact() and implement getContacts ():
 
 ::
 
 	/**
-	 * @var Tx_Extbase_Persistence_ObjectStorage<Tx_SjrOffers_Domain_Model_Person> The contacts of the organization
+	 * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\MyVendor\SjrOffers\Domain\Model\Person> The contacts of the organization
 	 */
 	protected $contacts;
 
 	/**
 	 * Adds a contact to the organization
 	 *
-	 * @param Tx_SjrOffers_Domain_Model_Person The contact to be added
+	 * @param \MyVendor\SjrOffers\Domain\Model\Person The contact to be added
 	 * @return void
 	 */
-	public function addContact(Tx_SjrOffers_Domain_Model_Person $contact) {
+	public function addContact(\MyVendor\SjrOffers\Domain\Model\Person $contact) {
 		$this->contacts->attach($contact);
 	}
 
 	/**
 	 * Returns the contacts of the organization
 	 *
-	 * @return Tx_Extbase_Persistence_ObjectStorage<Tx_SjrOffers_Domain_Model_Person> The contacts of the organization
+	 * @return \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\MyVendor\SjrOffers\Domain\Model\Person> The contacts of the organization
 	 */
 	public function getContacts() {
 		return clone $this->contacts;
@@ -278,10 +286,10 @@ and m:n relationships the add and remove methods are added.
 
 ::
 
-	setContacts(Tx_Extbase_Persistence_ObjectStorage $contacts)
+	setContacts(\TYPO3\CMS\Extbase\Persistence\ObjectStorage $contacts)
 	getContacts()
-	addContact(Tx_SjrOffers_Domain_Model_Contact $contact)
-	removeContact(Tx_SjrOffers_Domain_Model_Contact $contact)
+	addContact(\MyVendor\SjrOffers\Domain\Model\Contact $contact)
+	removeContact(\MyVendor\SjrOffers\Domain\Model\Contact $contact)
 
 Be careful about the subtle differences here. The methods and setContacts
 getContacts refer simultaneously to all contacts. They expect and hence provide
@@ -298,7 +306,7 @@ annotations:
 ::
 
 	/**
-	 * @var Tx_Extbase_Persistence_ObjectStorage<Tx_SjrOffers_Domain_Model_Offer> The offers the organization has to offer
+	 * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\MyVendor\SjrOffers\Domain\Model\Offer> The offers the organization has to offer
 	 * @lazy
 	 * @cascade remove
 	 */
@@ -336,7 +344,7 @@ supported annotations, see the index.
 So far, the impression may arise that domain models consist only of setters and
 getters. The domain objects, however, contain the main part of the business
 logic. In the following section, we add to our class
-Tx_SjrOffers_Domain_Model_Organization a small part of this business logic.
+\MyVendor\SjrOffers\Domain\Model\Organization a small part of this business logic.
 
 
 Adding business logic to the domain objects
@@ -390,17 +398,20 @@ once in the list.
 	actually a performance problem.
 
 We finish that implementation of the class from
-Tx_SjrOffers_Domain_Model_Organization and turn to the class
-Tx_SjrOffers_Domain_Model_Offer. The basic approach here is not fundamentally
+\MyVendor\SjrOffers\Domain\Model\Organization and turn to the class
+\MyVendor\SjrOffers\Domain\Model\Offer. The basic approach here is not fundamentally
 different from the last. Let's take a look at the (shortened) class which
 emphasizes some peculiarities.
 
 ::
 
-	class Tx_SjrOffers_Domain_Model_Offer extends Tx_Extbase_DomainObject_AbstractEntity {
+	<?php
+	namespace \MyVendor\SjrOffers\Domain\Model;
+
+	class Offer extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity {
 
 		/**
-		 * @var Tx_SjrOffers_Domain_Model_Organization The organization of the offer
+		 * @var \MyVendor\SjrOffers\Domain\Model\Organization The organization of the offer
 		 */
 		protected $organization;
 		protected $title;
@@ -411,31 +422,31 @@ emphasizes some peculiarities.
 		protected $dates;
 		protected $venue;
 		/**
-		 * @var Tx_SjrOffers_Domain_Model_AgeRange The age range of the offer.
+		 * @var \MyVendor\SjrOffers\Domain\Model\AgeRange The age range of the offer.
 		 */
 		protected $ageRange;
 		/**
-		 * @var Tx_SjrOffers_Domain_Model_DateRange The date range of the offer.
+		 * @var \MyVendor\SjrOffers\Domain\Model\DateRange The date range of the offer.
 		 */
 		protected $dateRange;
 		/**
-		 * @var Tx_SjrOffers_Domain_Model_AttendanceRange The attendance range.
+		 * @var \MyVendor\SjrOffers\Domain\Model\AttendanceRange The attendance range.
 		 */
 		protected $attendanceRange;
 		/**
-		 * @var Tx_Extbase_Persistence_ObjectStorage<Tx_SjrOffers_Domain_Model_AttendanceFee>
+		 * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\MyVendor\SjrOffers\Domain\Model\AttendanceFee>
 		 */
 		protected $attendanceFees;
 		/**
-		 * @var Tx_SjrOffers_Domain_Model_Person The contact of the offer
+		 * @var \MyVendor\SjrOffers\Domain\Model\Person The contact of the offer
 		 */
 		protected $contact;
 		/**
-		 * @var Tx_Extbase_Persistence_ObjectStorage<Tx_SjrOffers_Domain_Model_Category> The categories the offer is assigned to
+		 * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\MyVendor\SjrOffers\Domain\Model\Category> The categories the offer is assigned to
 		 */
 		protected $categories;
 		/**
-		 * @var Tx_Extbase_Persistence_ObjectStorage<Tx_SjrOffers_Domain_Model_Region> The regions the offer is available
+		 * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\MyVendor\SjrOffers\Domain\Model\Region> The regions the offer is available
 		 */
 		protected $regions;
 
@@ -444,9 +455,9 @@ emphasizes some peculiarities.
 		 */
 		public function __construct($title) {
 			$this->setTitle($title);
-			$this->setAttendanceFees(new Tx_Extbase_Persistence_ObjectStorage);
-			$this->setCategories(new Tx_Extbase_Persistence_ObjectStorage);
-			$this->setRegions(new Tx_Extbase_Persistence_ObjectStorage);
+			$this->setAttendanceFees(new \TYPO3\CMS\Extbase\Persistence\ObjectStorage);
+			$this->setCategories(new \TYPO3\CMS\Extbase\Persistence\ObjectStorage);
+			$this->setRegions(new \TYPO3\CMS\Extbase\Persistence\ObjectStorage);
 		}
 		// Getter and Setter
 	}
@@ -466,7 +477,7 @@ Organization (Aggregate Root) should.
 	offer-tuple associated with the corresponding tuple from the table
 	tx_sjroffers_domain_model_organization. We use here sent from the fact that the
 	integer value of the uid is converted by Extbase because of the annotation @var
-	Tx_Sjr Offers_Domain_Model_Organization into the corresponding object
+	\MyVendor\SjrOffers\Domain\Model\Organization into the corresponding object
 	Organization.
 
 The properties ageRange, dateRange and attendanceRange contains the objects of
@@ -511,7 +522,10 @@ In the class Range Constraint all common properties and methods are gathered. Th
 
 ::
 
-	abstract class Tx_SjrOffers_Domain_Model_RangeConstraint extends Tx_Extbase_DomainObject_AbstractValueObject {
+	<?php
+	namespace \MyVendor\SjrOffers\Domain\Model;
+
+	abstract class RangeConstraint extends \TYPO3\CMS\Extbase\DomainObject\AbstractValueObject {
 
 		/**
 		 * @var int The minimum value
@@ -566,7 +580,7 @@ In the class Range Constraint all common properties and methods are gathered. Th
 		}
 	}
 
-All of this range objects have beyond their properties and methods further things in common. They have no identity other than the whole of their property values. It is not important for the offer, which age range »from 12 till 15 years« the range object is assigned to receive. Of importance isonly the two values 12 and 15. Are two offers designed for the same age range, so Extbase must therefore do not pay attention to the fact that it assigns a particular age range with the values ​​12 and 15 to the offer. Value Objects can e.g. occur multiple times in memory, and therefore any be copied while it was driving in the major entities of the ambiguity problem. The internal handling is much more easier because of this. We thus have to Extbase to treat the object as a Value Object Constraint Range by inheriting from the appropriate Extbase class: extends Tx_Extbase_DomainObject_Abstract-ValueObject.
+All of this range objects have beyond their properties and methods further things in common. They have no identity other than the whole of their property values. It is not important for the offer, which age range »from 12 till 15 years« the range object is assigned to receive. Of importance isonly the two values 12 and 15. Are two offers designed for the same age range, so Extbase must therefore do not pay attention to the fact that it assigns a particular age range with the values ​​12 and 15 to the offer. Value Objects can e.g. occur multiple times in memory, and therefore any be copied while it was driving in the major entities of the ambiguity problem. The internal handling is much more easier because of this. We thus have to Extbase to treat the object as a Value Object Constraint Range by inheriting from the appropriate Extbase class: extends \TYPO3\CMS\Extbase\DomainObject\AbstractValueObject.
 
 The class rank by the keyword abstract constraint was marked as abstract. Thus we prevent the Range object itself is instantiated.
 
@@ -574,16 +588,19 @@ We have furthermore implement a method normalizeValue(). These »adjusted« the 
 
 ::
 
- class Tx_SjrOffers_Domain_Model_DateRange extends Tx_SjrOffers_Domain_Model_RangeConstraint
- implements Tx_SjrOffers_Domain_Model_DateRangeInterface {
+ 	<?php
+	namespace \MyVendor\SjrOffers\Domain\Model;
+
+	class DateRange extends \MyVendor\SjrOffers\Domain\Model\RangeConstraint
+ implements \MyVendor\SjrOffers\Domain\Model\DateRangeInterface {
 
 	/**
-	 * @var Tx_SjrOffers_Domain_Model_DateTime The minimum value
+	 * @var \MyVendor\SjrOffers\Domain\Model\DateTime The minimum value
 	 */
 	protected $minimumValue;
 
 	/**
-	 * @var Tx_SjrOffers_Domain_Model_DateTime The maximum value
+	 * @var \MyVendor\SjrOffers\Domain\Model\DateTime The maximum value
 	 */
 	protected $maximumValue;
 
@@ -599,16 +616,18 @@ We have furthermore implement a method normalizeValue(). These »adjusted« the 
 The class DateRange implements furthermore the interface DateRangeInterface. The interface on is own is empty and is only used for identification. This makes especially sense for the other two Range Objects. These both implent the NumericRangeInterface. The classes AgeRange and AttendanceRange Classes are otherwise empty hulls, because they inherit all the properties and methods from the object RangeConstraint.
 
 ::
+ <?php
+ namespace \MyVendor\SjrOffers\Domain\Model;
 
- class Tx_SjrOffers_Domain_Model_AgeRange extends Tx_SjrOffers_Domain_Model_RangeConstraint
- implements Tx_SjrOffers_Domain_Model_NumericRangeInterface {
+ class AgeRange extends \MyVendor\SjrOffers\Domain\Model\RangeConstraint
+ implements \MyVendor\SjrOffers\Domain\Model\NumericRangeInterface {
  }
- class Tx_SjrOffers_Domain_Model_AttendanceRange extends Tx_SjrOffers_Domain_Model_RangeConstraint
- implements Tx_SjrOffers_Domain_Model_NumericRangeInterface {
+ class AttendanceRange extends \MyVendor\SjrOffers\Domain\Model\RangeConstraint
+ implements \MyVendor\SjrOffers\Domain\Model\NumericRangeInterface {
  }
- interface Tx_SjrOffers_Domain_Model_NumericRangeInterface {}
+ interface \MyVendor\SjrOffers\Domain\Model\NumericRangeInterface {}
 
- interface Tx_SjrOffers_Domain_Model_DateRangeInterface {}
+ interface \MyVendor\SjrOffers\Domain\Model\DateRangeInterface {}
 
 
 
@@ -690,45 +709,45 @@ Therefore Extbase offers an alternative about Annotations. Let us have a look at
 	protected $venue;
 
 	/**
-	 * @var Tx_SjrOffers_Domain_Model_AgeRange The age range of the offer.
-	 * @validate Tx_SjrOffers_Domain_Validator_RangeConstraintValidator
+	 * @var \MyVendor\SjrOffers\Domain\Model\AgeRange The age range of the offer.
+	 * @validate \MyVendor\SjrOffers\Domain\Validator\RangeConstraintValidator
 	 */
 	protected $ageRange;
 
 	/**
-	 * @var Tx_SjrOffers_Domain_Model_DateRange The date range of the offer is valid.
-	 * @validate Tx_SjrOffers_Domain_Validator_RangeConstraintValidator
+	 * @var \MyVendor\SjrOffers\Domain\Model\DateRange The date range of the offer is valid.
+	 * @validate \MyVendor\SjrOffers\Domain\Validator\RangeConstraintValidator
 	 */
 	protected $dateRange;
 
 	/**
-	 * @var Tx_SjrOffers_Domain_Model_AttendanceRange The attendance range of the offer.
-	 * @validate Tx_SjrOffers_Domain_Validator_RangeConstraintValidator
+	 * @var \MyVendor\SjrOffers\Domain\Model\AttendanceRange The attendance range of the offer.
+	 * @validate \MyVendor\SjrOffers\Domain\Validator\RangeConstraintValidator
 	 */
 	protected $attendanceRange;
 
 	/**
-	 * @var Tx_Extbase_Persistence_ObjectStorage<Tx_SjrOffers_Domain_Model_AttendanceFee> The attendance fees of the offer
+	 * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\MyVendor\SjrOffers\Domain\Model\AttendanceFee> The attendance fees of the offer
 	 */
 	protected $attendanceFees;
 
 	/**
-	 * @var Tx_SjrOffers_Domain_Model_Person The contact of the offer
+	 * @var \MyVendor\SjrOffers\Domain\Model\Person The contact of the offer
 	 */
 	protected $contact;
 
 	/**
-	 * @var Tx_Extbase_Persistence_ObjectStorage<Tx_SjrOffers_Domain_Model_Category> The categories the offer is assigned to
+	 * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\MyVendor\SjrOffers\Domain\Model\Category> The categories the offer is assigned to
 	*/
 	protected $categories;
 
 	/**
-	 * @var Tx_Extbase_Persistence_ObjectStorage<Tx_SjrOffers_Domain_Model_Region> The regions the offer is available
+	 * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\MyVendor\SjrOffers\Domain\Model\Region> The regions the offer is available
 	 */
 	protected $regions;
 
 The values of some properties must be checked to control the offer being classified as valid. Which rule will narrow, about the annotation @validate [...] is set. The annotation @validate StringLength (minimum = 3, maximum = 50) on the property title effected, for example, that the title length is not smaller than 3 characters and not longer than 50 characters.
-The validator StringLength is provided by Extbase of charge. The name of the associated class is Tx_Extbase_Validation_Validator_StringLengthValidator. The options minimum and maximum are passed to the Validator and are evaluated there.
+The validator StringLength is provided by Extbase of charge. The name of the associated class is \TYPO3\CMS\Extbase\Validation\Validator\StringLengthValidator. The options minimum and maximum are passed to the Validator and are evaluated there.
 
 With the validation, we conclude the modeling and implementation of the domain at first. With that achieved, it is possible to store domain objects, which where generated during a page view in memory. All data will be lost at the end
 of the page view. In order for the domain objects are permanently on the grouting, the persistence layer is to be set up accordingly.

--- a/Documentation/6-Persistence/1-prepare-the-database.rst
+++ b/Documentation/6-Persistence/1-prepare-the-database.rst
@@ -23,7 +23,7 @@ Preparing the tables of the Domain Objects
 
 Let's have a look at the definition of the database table which will
 aggregate the objects of the class
-:class:`Tx_SjrOffers_Domain_Model_Organization`:
+:class:`\MyVendor\SjrOffers\Domain\Model\Organization`:
 
 ::
 
@@ -463,9 +463,9 @@ Key in the table of the child object. In TYPO3, the parental object's
 table holds a separate value for counting the sum of the corresponding
 child objects. Consecutively, we list the definition of the relationship
 between the organization and its offers of the class
-``Tx_Sjr_Offers_Domain_Model_Organization``. This will later be
+``\MyVendor\SjrOffers\Domain\Model\Organization``. This will later be
 filled with instances of the class
-``Tx_Sjr_Offers_Domain_Model_Offer``.
+``\MyVendor\SjrOffers\Domain\Model\Offer``.
 
 ::
 
@@ -492,9 +492,9 @@ The definition of the table
 	Extbase stores the relationship between ``organization``
 	and the offer as a ``1:1-relationship``. This can be taken as
 	advantage by adding the property ``organization`` to the class
-	``Tx_Sjr_Offers_Domain_Model_Offer``. Consequently, it will be
+	``\MyVendor\SjrOffers\Domain\Model\Offer``. Consequently, it will be
 	filled with an instance of the class
-	``Tx_Sjr_Offers_Domain_Model_Organization`` and can therefore
+	``\MyVendor\SjrOffers\Domain\Model\Organization`` and can therefore
 	be used as a backreference from the offer to its corresponding
 	organization.
 

--- a/Documentation/6-Persistence/2-configure-the-backends-inputforms.rst
+++ b/Documentation/6-Persistence/2-configure-the-backends-inputforms.rst
@@ -641,8 +641,8 @@ contains the following stuff::
 		'enablecolumns' => array(
 			'disabled'	=> 'hidden'
 		),
-		'dynamicConfigFile'		=> t3lib_extMgm::extPath($_EXTKEY) . 'Configuration/TCA/tca.php',
-		'iconfile'	=> t3lib_extMgm::extRelPath($_EXTKEY) . 'Resources/Public/Icons/icon_tx_sjroffers_domain_model_organization.gif'
+		'dynamicConfigFile'		=> \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY) . 'Configuration/TCA/tca.php',
+		'iconfile'	=> \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath($_EXTKEY) . 'Resources/Public/Icons/icon_tx_sjroffers_domain_model_organization.gif'
 		)
 	);
 
@@ -712,21 +712,24 @@ We have already introduced the Repositories in Chapter 3. They serve with
 capabilities to save and reaccess our objects. We set up such a Repository
 object for every Aggregate-Root object which are, then again, used for accessing
 all the Aggregate-Root's corresponding objects. In our concrete example
-``Tx_SjrOffers_Domain_Model_Organization`` is such an Aggregate-Root object. The
+``\MyVendor\SjrOffers\Domain\Model\Organization`` is such an Aggregate-Root object. The
 Repository's class name is derived from the class name of the Aggregate-Root
 object concatenated with the suffic *Repository*. The Repository needs to extend
-the class ``Tx_Extbase_Persistence_Repository``. The class file ``Tx_
-SjrOffers_Domain_Repository_OrganizationRepository`` will be saved in the
+the class ``\TYPO3\CMS\Extbase\Persistence\Repository``. The class file ``\MyVendor\
+SjrOffers\Domain\Repository\OrganizationRepository`` will be saved in the
 directory *EXT:sjr_ offers/Classes/Domain/Repository/*. Thus the directory
 *Repository* is on the same hierarchy-level as the direcory *Model*. In our
 case, the class body remains empty because all the important functionalities are
 already generically implemented in the super-class
-``Tx_Extbase_Persistence_Repository``.
+``\TYPO3\CMS\Extbase\Persistence\Repository``.
 
 ::
-	class Tx_SjrOffers_Domain_Repository_OrganizationRepository extends Tx_Extbase_Persistence_Repository {}
+	<?php
+	namespace \MyVendor\SjrOffers\Domain\Repository;
 
-We create a ``Tx_SjrOffers_Domain_Repository_OfferRepository`` exactly the same
+	class OrganizationRepository extends \TYPO3\CMS\Extbase\Persistence\Repository {}
+
+We create a ``\MyVendor\SjrOffers\Domain\Repository\OfferRepository`` exactly the same
 way but we will later extend it with own methods for accessing offers. It's very
 likely that we have to access the other objects for categories, regions and
 update data of contact informations of certain persons independent of the offers
@@ -739,7 +742,7 @@ objects for easier access from the Frontend.
 	yourself to a minimal number of Repositories. Instead, you should define the
 	access methods within the Aggregate-Root objects as ``find`` methods.
 
-``Tx_Extbase_Persistence_Repository`` serves with the following methods which
+``\TYPO3\CMS\Extbase\Persistence\Repository`` serves with the following methods which
 are of course accessable and overwritable in the extending child derivations:
 
 
@@ -915,7 +918,7 @@ normally deactivated due to its huge effects on performance. Before calling a
 Repository's methods they need to be instantiated at first with the TYPO3-API
 method ``makeInstance()``::
 
-	$offerRepository = t3lib_div::makeInstance('Tx_SjrOffers_Domain_Repository_ OfferRepository');
+	$offerRepository = GeneralUtility::makeInstance('\MyVendor\SjrOffers\Domain\Repository\OfferRepository');
 
 .. warning::
 

--- a/Documentation/6-Persistence/3-implement-individual-database-queries.rst
+++ b/Documentation/6-Persistence/3-implement-individual-database-queries.rst
@@ -18,9 +18,9 @@ natural language this would sound as follows:
 
 There are principally two ways of implementing such methods. On the one hand, you
 could request all the offers from the Backend and filter them manually. This is
-flexible and easy to implement. On the other hand, you could write a request 
-matching your criteria exactly and execute it. Contrary to the first case, 
-this method would only build the objects that are really needed, which 
+flexible and easy to implement. On the other hand, you could write a request
+matching your criteria exactly and execute it. Contrary to the first case,
+this method would only build the objects that are really needed, which
 positively affects the performance of your application.
 
 
@@ -60,7 +60,7 @@ object. However, we have to define such a parameter to implement the first
 specified request, "Find all the offers for a certain region". Thus, the
 corresponding method looks as follows::
 
-    public function findInRegion(Tx_SjrOffers_Domain_Model_Region $region) {
+    public function findInRegion(\MyVendor\SjrOffers\Domain\Model\Region $region) {
         $query = $this->createQuery();
         $query->matching($query->contains('regions', $region));
         return $query->execute();
@@ -74,7 +74,7 @@ other methods each of which returns a *Constraint* object. Those methods may be
 roughly split into two groups: Comparing operations and Boolean operations.
 The first group leads to a comparison between the value of a given property
 and another operand. The latter mentioned operations connect two conditions to
-one condition by the rules of Boolean Algebra and may 
+one condition by the rules of Boolean Algebra and may
 respectively negate a result. The following Comparing operations are acceptable::
 
     equals($propertyName, $operand, $caseSensitive = TRUE)
@@ -136,7 +136,7 @@ types (1:1, 1:n, m:n) and all comparison operators are covered by this feature.
     object properties with the notation ``{organization.administrator.name}``.
     However, Fluid does not support the notation
     ``{organization.offers.categories.title}``, so that in
-    ``$query->equals('offers.categories.title', 'foo')`` it is possible to die, 
+    ``$query->equals('offers.categories.title', 'foo')`` it is possible to die,
     due to Fluid's limitation that property access is not possible in a
     "concatenated way".
 
@@ -156,7 +156,7 @@ accept an Array of constraints. Last, but not least, the function
 yields *false* and *false* yields *true*. Given this information, you can create
 complex queries such as::
 
-    public function findMatchingOrganizationAndRegion(Tx_SjrOffers_Domain_Model_Organization $organization, Tx_SjrOffers_Domain_Model_Region $region) {
+    public function findMatchingOrganizationAndRegion(\MyVendor\SjrOffers\Domain\Model\Organization $organization, \MyVendor\SjrOffers\Domain\Model\Region $region) {
         $query = $this->createQuery();
         $query->matching(
             $query->logicalAnd(
@@ -180,7 +180,7 @@ In addition to the restrictions for the needs of the user, there comes the reque
 to show the current offers. This example request denotes a date constraint at most one week ago.
 In the method ``findDemanded()`` of the ``offerRepository``, the request is implemented::
 
-    public function findDemanded(Tx_SjrOffers_Domain_Model_Demand $demand) {
+    public function findDemanded(\MyVendor\SjrOffers\Domain\Model\Demand $demand) {
         $query = $this->createQuery();
         $constraints = array();
         if ($demand->getRegion() !== NULL) {
@@ -219,7 +219,7 @@ In the method ``findDemanded()`` of the ``offerRepository``, the request is impl
 The ``Demand`` object is passed as an argument. In the first line, the ``Query`` object is created.
 All single constraint terms are then collected in the array ``$constraints``. The
 ``$query->logicalAnd($constraints)`` instruction brings together these constraint terms, and
-they are assigned to the ``Query`` object via ``matching()``. With ``return $query->execute();``, the 
+they are assigned to the ``Query`` object via ``matching()``. With ``return $query->execute();``, the
 query is executed and the located ``Offer`` objects are returned to the caller.
 
 The example's offer age range requirement is interesting.
@@ -237,51 +237,51 @@ The example's offer age range requirement is interesting.
         ),
     );
 
-This requirement is fulfilled using multiple levels of nested query constraints. Each ``logicalOr()`` 
-condition allows either an unset age (value ``equals() NULL``) or a boundary 
-age value. (Here, the minimum age is more recent in the past than the maximum age, on a timeline.) 
-The ``logicalAnd()`` constraint then joins the two ``logicalOr()`` constraints, making a single 
+This requirement is fulfilled using multiple levels of nested query constraints. Each ``logicalOr()``
+condition allows either an unset age (value ``equals() NULL``) or a boundary
+age value. (Here, the minimum age is more recent in the past than the maximum age, on a timeline.)
+The ``logicalAnd()`` constraint then joins the two ``logicalOr()`` constraints, making a single
 constraint, overall.
 
 You can sort the result of a query by assigning one or more rules ``$query->setOrderings($orderings);``
-to the ``Query`` object. These rules are collected in an associative array. Each array element has the 
+to the ``Query`` object. These rules are collected in an associative array. Each array element has the
 property name on which the sort is based as its key, and the search order constant as its value.
-There are two constants for the search order: ``Tx_Extbase_Persistence_QueryInterface:ORDER_ASCENDING``
-for an ascending order, and ``Tx_Extbase_Persistence_QueryInterface:ORDER_DESCENDING`` for a descending
+There are two constants for the search order: ``\TYPO3\CMS\Extbase\Persistence\Generic\QueryInterface:ORDER_ASCENDING``
+for an ascending order, and ``\TYPO3\CMS\Extbase\Persistence\Generic\QueryInterface:ORDER_DESCENDING`` for a descending
 order. A complete sample for specifying a sort order looks like this::
 
     $query->setOrderings(
         array(
-            'organization.name' => Tx_Extbase_Persistence_QueryInterface::ORDER_ASCENDING,
-            'title' => Tx_Extbase_Persistence_QueryInterface:ORDER_ASCENDING
+            'organization.name' => \TYPO3\CMS\Extbase\Persistence\Generic\QueryInterface::ORDER_ASCENDING,
+            'title' => \TYPO3\CMS\Extbase\Persistence\Generic\QueryInterface:ORDER_ASCENDING
         )
     );
 
 Multiple orderings are processed in the specified order. In our sample the offers are ordered first
 by the name of the organization, then inside the organization by the title of the offers, both in ascending
-order (thus from A to Z). Since Extbase 1.1, you can use TypoScript-style point notation for 
+order (thus from A to Z). Since Extbase 1.1, you can use TypoScript-style point notation for
 specifying the property names.
 
 If you need only an extract of the result set, you can do this with the two parameters, ``Limit``
-and ``Offset``. Assuming you want to get the tenth up to thirtieth offers from the overall query result 
+and ``Offset``. Assuming you want to get the tenth up to thirtieth offers from the overall query result
 from the repository, you can use the following lines::
 
     $query->setOffset(10);
     $query->setLimit(20);
 
 Both methods expect an integer value. With the method ``setOffset()``, you set the pointer to the
-object you will start with. With the method ``setLimit()``, you set the maximum count of objects you will 
+object you will start with. With the method ``setLimit()``, you set the maximum count of objects you will
 get.
 
 At first, the usage of a ``Query`` object with ``Constraint`` objects instead of directly written
-SQL statements looks very inefficient. But doing so here in Extbase makes possible a complete abstraction 
+SQL statements looks very inefficient. But doing so here in Extbase makes possible a complete abstraction
 of the storage backend. FLOW3 does the same with its ``Query`` object and an identical API, so you can now
 easily port your query code to FLOW3.
 
 .. note::
 
     The ``Query`` object leans against the *Java Specification Request* (JSR) 283. JSR 283
-    describes a standardised content repository for Java, The FLOW3 team ported this idea to PHP. You can 
+    describes a standardised content repository for Java, The FLOW3 team ported this idea to PHP. You can
     find more information about this at
     :file:`http://jcp.org/en/jsr/detail?id=283`.
 
@@ -338,18 +338,18 @@ look at an object with a single value property.
     )
 
 In Extbase, the value for ``<identifier>`` is always the UID of the data record. The class name
-``<classname>`` and the identifier together make the element unique across the whole database. The 
-properties are stored in an own associative array. The name of the property is the key and the 
-corresponding information of the properties are the value. The property is signed with the property 
-type ``<type>`` and the property value ``<value>`` itself. The property type could be ``string``, ``integer``, 
-``DateTime``, or a class name like ``Tx_SjrOffers_Domain_Model_Organization``, for example. The property 
+``<classname>`` and the identifier together make the element unique across the whole database. The
+properties are stored in an own associative array. The name of the property is the key and the
+corresponding information of the properties are the value. The property is signed with the property
+type ``<type>`` and the property value ``<value>`` itself. The property type could be ``string``, ``integer``,
+``DateTime``, or a class name like ``\MyVendor\SjrOffers\Domain\Model\Organization``, for example. The property
 is declared as single value per default (``'multivalue' => FALSE``).
 
 The array of an object with a multivalue property is basically composed the same way. The actual value of the
 property is not a simple data type (like a string or a single object), but an array of data types.
 This array could also be empty, and instead of the array, a NULL value is possible. The property type
-for multivalue properties is always ``Tx_Extbase_Persistence_ObjectStorage``. In the future, other containers
-like ``array`` or ``splObjectStorage`` may be supported. The property is per definition declared as 
+for multivalue properties is always ``\TYPO3\CMS\Extbase\Persistence\ObjectStorage``. In the future, other containers
+like ``array`` or ``splObjectStorage`` may be supported. The property is per definition declared as
 multivalue (``'multivalue' => TRUE``).
 
 ::
@@ -359,7 +359,7 @@ multivalue (``'multivalue' => TRUE``).
         'classname' => '<classname>',
         'properties' => array(
             '<name>' => array(
-                'type' => '<type>',  // always 'Tx_Extbase_Persistence_ObjectStorage'
+                'type' => '<type>',  // always '\TYPO3\CMS\Extbase\Persistence\ObjectStorage'
                 'multivalue' => TRUE,
                 'value' => array(
                     array(

--- a/Documentation/6-Persistence/4-use-foreign-data-sources.rst
+++ b/Documentation/6-Persistence/4-use-foreign-data-sources.rst
@@ -12,7 +12,7 @@ Extbase building-up strongly of the rule "Convention over Configuration" (see al
 Foreign database tables correspond in rare cases the conventions of Extbase. Therefore the assignment
 of the class to a given table as well as the assignment of field names to property names of the classes
 must be configured via TypoScript. This assignment is also called *mapping*. The following configuration
-enables the storage of the object data of a class ``Tx_MyExtension_Domain_Model_Person`` in the table
+enables the storage of the object data of a class ``\MyVendor\MyExtension\Domain\Model\Person`` in the table
 ``tt_address``, which is available in most TYPO3 installations.
 
 ::
@@ -20,10 +20,10 @@ enables the storage of the object data of a class ``Tx_MyExtension_Domain_Model_
     plugin.tx_myextension {
         persistence {
             classes {
-                Tx_MyExtension_Domain_Model_Person {
+                \MyVendor\MyExtension\Domain\Model\Person {
                     mapping {
                         tableName = tt_address
-                        recordType = Tx_MyExtension_Domain_Model_Person
+                        recordType = \MyVendor\MyExtension\Domain\Model\Person
                         columns {
                             birthday.mapOnProperty = dateOfBirth
                             street.mapOnProperty = thoroughfare
@@ -47,7 +47,7 @@ assignments of the field names (left) to the corresponding properties (right) is
     you will find in "Preparing the tables of the Domain Objects" above in this chapter.
 
 This configuration causes Extbase to use the table ``tt_address`` when reconstructing or persisting of
-objects of the class ``Tx_MyExtension_Domain_Model_Person``. Thereby the values of the properties
+objects of the class ``\MyVendor\MyExtension\Domain\Model\Person``. Thereby the values of the properties
 ``dateOfBirth`` and ``thoroughfare`` are stored in the fields ``birthday`` and ``street``. If the
 configuration option ``tableName`` is not set, Extbase searches for a table that corresponds to the lower
 cased cased class name, in our case: ``tx_myextension_domain_model_person``. If for a property

--- a/Documentation/6-Persistence/5-modeling-the-class-hierarchy.rst
+++ b/Documentation/6-Persistence/5-modeling-the-class-hierarchy.rst
@@ -82,32 +82,32 @@ data of the instances are stored and with which type they should be stored.
 ::
 
     config.tx_extbase.persistence.classes {
-        Tx_MyExtension_Domain_Model_Organization {
+        \MyVendor\MyExtension\Domain\Model\Organization {
             mapping {
                 tableName = tx_myextension_domain_model_party
-                recordType = Tx_MyExtension_Domain_Model_Organization
+                recordType = \MyVendor\MyExtension\Domain\Model\Organization
             }
             subclasses {
-                Tx_MyExtension_Domain_Model_Company = Tx_MyExtension_Domain_Model_Company
-                Tx_MyExtension_Domain_Model_ScientificInstitution = Tx_MyExtension_Domain_Model_ScientificInstitution
+                \MyVendor\MyExtension\Domain\Model\Company = \MyVendor\MyExtension\Domain\Model\Company
+                \MyVendor\MyExtension\Domain\Model\ScientificInstitution = \MyVendor\MyExtension\Domain\Model\ScientificInstitution
             }
         }
-        Tx_MyExtension_Domain_Model_Person {
+        \MyVendor\MyExtension\Domain\Model\Person {
             mapping {
                 tableName = tx_myextension_domain_model_party
-                recordType = Tx_MyExtension_Domain_Model_Person
+                recordType = \MyVendor\MyExtension\Domain\Model\Person
             }
         }
-        Tx_MyExtension_Domain_Model_Company {
+        \MyVendor\MyExtension\Domain\Model\Company {
             mapping {
                 tableName = tx_myextension_domain_model_party
-                recordType = Tx_MyExtension_Domain_Model_Company
+                recordType = \MyVendor\MyExtension\Domain\Model\Company
             }
         }
-        Tx_MyExtension_Domain_Model_ScientificInstitution {
+        \MyVendor\MyExtension\Domain\Model\ScientificInstitution {
             mapping {
                 tableName = tx_myextension_domain_model_party
-                recordType = Tx_MyExtension_Domain_Model_ScientificInstitution
+                recordType = \MyVendor\MyExtension\Domain\Model\ScientificInstitution
             }
         }
     }
@@ -138,13 +138,13 @@ including the following configuration to your TCA::
         'ctrl' => $TCA['tx_myextension_domain_model_party']['ctrl'],
         'types' => array(
             '0' => array('showitem' => 'record_type, name'),
-            'Tx_MyExtension_Domain_Model_Organization' => array('showitem' => 'record_type,
+            '\MyVendor\MyExtension\Domain\Model\Organization' => array('showitem' => 'record_type,
                 name, numberOfEmployees'),
-            'Tx_MyExtension_Domain_Model_Person' => array('showitem' => 'record_type, name,
+            '\MyVendor\MyExtension\Domain\Model\Person' => array('showitem' => 'record_type, name,
                 dateOfBirth'),
-            'Tx_MyExtension_Domain_Model_Company' => array('showitem' => 'record_type, name,
+            '\MyVendor\MyExtension\Domain\Model\Company' => array('showitem' => 'record_type, name,
                 numberOfEmployees, typeOfBusiness'),
-            'Tx_MyExtension_Domain_Model_ScientificInstitution' => array('showitem' =>
+            '\MyVendor\MyExtension\Domain\Model\ScientificInstitution' => array('showitem' =>
                 'record_type, name, numberOfEmployees, researchFocus')
         ),
         'columns' => array(
@@ -155,13 +155,13 @@ including the following configuration to your TCA::
                     'type' => 'select',
                     'items' => array(
                         array('undefined', '0'),
-                        array('Organization', 'Tx_MyExtension_Domain_Model_Organization'),
-                        array('Person', 'Tx_MyExtension_Domain_Model_Person'),
-                        array('Company', 'Tx_MyExtension_Domain_Model_Company'),
+                        array('Organization', '\MyVendor\MyExtension\Domain\Model\Organization'),
+                        array('Person', '\MyVendor\MyExtension\Domain\Model\Person'),
+                        array('Company', '\MyVendor\MyExtension\Domain\Model\Company'),
                         array('ScientificInstitution',
-                            'Tx_MyExtension_Domain_Model_ScientificInstitution')
+                            '\MyVendor\MyExtension\Domain\Model\ScientificInstitution')
                     ),
-                    'default' => 'Tx_MyExtension_Domain_Model_Person'
+                    'default' => '\MyVendor\MyExtension\Domain\Model\Person'
                 )
             ),
             ...
@@ -177,17 +177,17 @@ are displayed after a confirmation by TYPO3.
 You can access the objects via repositories as normal. In your controller the corresponding lines
 can look like this::
 
-    $companyRepository = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('Tx_MyExtension_Domain_Repository_CompanyRepository');
+    $companyRepository = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('\MyVendor\MyExtension\Domain\Repository\CompanyRepository');
     $companies = $companyRepository->findAll();
 
 You can also find straightforward all concret classas of a super class::
 
-    $organizationRepository = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('Tx_MyExtension_Domain_Repository_OrganizationRepository');
+    $organizationRepository = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('\MyVendor\MyExtension\Domain\Repository\OrganizationRepository');
     $organizations = $organizationRepository->findAll();
 
 In the result set ``$organizationRepository`` there are domain objects of the class
-``Tx_MyExtension_Domain_Model_Organization`` and all configured subclasses ``Tx_MyExtension_Domain_Model_Company``
-and ``Tx_MyExtension_Domain_Model_ScientificInstitution`` are included. The query of a super class
+``\MyVendor\MyExtension\Domain\Model\Organization`` and all configured subclasses ``\MyVendor\MyExtension\Domain\Model\Company``
+and ``\MyVendor\MyExtension\Domain\Model\ScientificInstitution`` are included. The query of a super class
 is only possible for *Single Table Inheritanca* this time. In the future this should also be possible
 for *Concrete Table Inheritance*.
 

--- a/Documentation/7-Controllers/1-Creating-Controllers-and-Actions.rst
+++ b/Documentation/7-Controllers/1-Creating-Controllers-and-Actions.rst
@@ -7,18 +7,21 @@ The Controller classes are stored in the folder <link
 linkend="???">EXT:sjr_offer/Classes/Controller/</link>. The name of the
 Controller is composed by the name of the Domain Model and the Suffix
 :class:`Controller`. So the Controller
-:class:`Tx_SjrOffers_Controller_OfferController` is assigned
+:class:`\MyVendor\SjrOffers\Controller\OfferController` is assigned
 to the Aggegate Root Object
-:class:`Tx_SjrOffers_Domain_Model_Offer`. And the Name of the
+:class:`\MyVendor\SjrOffers\Domain\Model\Offer`. And the Name of the
 Class file is :file:`OfferController.php`.
 
 The Controller class must extend the class
-:class:`Tx_Extbase_MVC_Controller_ActionController` which is
+:class:`\TYPO3\CMS\Extbase\Mvc\Controller\ActionController` which is
 part of Extbase. The individual Actions are combined in seperate methods.
 The method names have to end in :class:`Action`. The body of
 :class:`OfferController` thus looks like this::
 
-    class Tx_SjrOffers_Controller_OfferController extends Tx_Extbase_MVC_Controller_ActionController {
+    <?php
+    namespace \MyVendor\SjrOffers\Controller;
+
+    class OfferController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController {
         // Action methods will be following here
     }
 
@@ -55,7 +58,7 @@ name of the Method::
 
     public function indexAction() {
 
-        $offerRepository = t3lib_div_makeInstance('Tx_SjrOffers_Domain_Repository_OfferRepository');
+        $offerRepository = t3lib_div_makeInstance('\MyVendor\SjrOffers\Domain\RepositoryOfferRepository');
 
         $offers = $offerRepository->findAll();
 
@@ -74,7 +77,7 @@ get::
     public function indexAction() {
 
         $offerRepository =
-        t3lib_div_makeInstance('Tx_SjrOffers_Domain_Repository_OfferRepository');
+        t3lib_div_makeInstance('\MyVendor\SjrOffers\Domain\RepositoryOfferRepository');
 
         $this->view->assign('offers', $offerRepository->findAll());
 
@@ -99,7 +102,7 @@ this::
 
     public function initializeAction() {
         $this->offerRepository =
-        t3lib_div::makeInstance('Tx_JjrOffers_Domain_Repository_OfferRepository');
+        GeneralUtility::makeInstance('\MyVendor\SjrOffers\Domain\Repository\OfferRepository');
     }
 
     public function indexAction() {
@@ -134,11 +137,11 @@ outside which Domain Object is to be displayed. In our case, the offer to
 be shown is passed to the Method as Argument::
 
     /**
-     * @param Tx_SjrOffers_Domain_Model_Offer $offer The offer to be shown
+     * @param \MyVendor\SjrOffers\Domain\Model\Offer $offer The offer to be shown
      * @return string The rendered HTML string
      */
 
-    public function showAction(Tx_SjrOffers_Domain_Model_Offer $offer) {
+    public function showAction(\MyVendor\SjrOffers\Domain\Model\Offer $offer) {
         $this->view->assign('offer', $offer);
     }
 
@@ -160,22 +163,22 @@ Extbase maps the arguments by their names. In our example Extbase detects,
 that the GET Argument :class:`tx_sjroffers_pi1[offer]=3
 `corresponds to the Method Argument
 :class:`$offer`:
-:class:`showAction(Tx_SjrOffers_Domain_Model_Offer
+:class:`showAction(\MyVendor\SjrOffers\Domain\Model\Offer
 *$offer*)`. The type of this Argument is
 fetched by Extbase from the Method signature:
-:class:`showAction(*Tx_SjrOffers_Domain_Model_Offer*
+:class:`showAction(*\MyVendor\SjrOffers\Domain\Model\Offer*
 $offer)`. In case this so called *Type Hint
 *should not be present, or (e.g. for the types *string
 *or *int* in PHP) not possible, Extbase reads
 the type from the commentary written above the Method: :class:`@param
-*Tx_SjrOffers_Domain_Model_Offer*
+*\MyVendor\SjrOffers\Domain\Model\Offer*
 $offer`.
 
 After successful assigning, the value of the incoming Argument has
 to be casted in the target type as well as checked for validity (read more
 about validation in chapter 9 in section "Validating Domain Objects"). In
 our case the incoming value is "3". Target type is the class
-:class:`Tx_SjrOffers_Domain_Model_Offer`. So Extbase
+:class:`\MyVendor\SjrOffers\Domain\Model\Offer`. So Extbase
 interprets the incoming value as uid of the Object to be created and sends
 a request to the *Storage Backend* to find an Object
 with this uid. If the Object can be reconstructed fully valid it is passed
@@ -236,14 +239,14 @@ Method :class:`newAction()`.
 ::
 
     /**
-     * @param Tx_SjrOffers_Domain_Model_Organization $organization The organization
-     * @param Tx_SjrOffers_Domain_Model_Offer $offer The new offer object
+     * @param \MyVendor\SjrOffers\Domain\Model\Organization $organization The organization
+     * @param \MyVendor\SjrOffers\Domain\Model\Offer $offer The new offer object
      * @return string An HTML form for creating a new offer
      * @dontvalidate $newOffer
      */
 
-    public function newAction(Tx_SjrOffers_Domain_Model_Organization $organization,
-    Tx_SjrOffers_Domain_Model_Offer $newOffer = NULL) {
+    public function newAction(\MyVendor\SjrOffers\Domain\Model\Organization $organization,
+    \MyVendor\SjrOffers\Domain\Model\Offer $newOffer = NULL) {
 
         $this->view->assign('organization',$organization);
 
@@ -263,7 +266,7 @@ section "Template Creation by example". After the user filled in the data
 of the offer and submitted the form, the Method
 :class:`createAction()` is called. It expects as Arguments
 an :class:`Organization `Object and an Object of the class
-:class:`Tx_SjrOffers_Domain_Model_Offer`. Therefore Extbase
+:class:`\MyVendor\SjrOffers\Domain\Model\Offer`. Therefore Extbase
 instantiates the Object and "fills" its Properties with the appropriate
 Form data. If all Arguments are valid, the Action
 :class:`createAction()` is called.

--- a/Documentation/7-Controllers/2-Configuring-and-embedding-Frontend-Plugins.rst
+++ b/Documentation/7-Controllers/2-Configuring-and-embedding-Frontend-Plugins.rst
@@ -41,7 +41,7 @@ plugin name, Extbase can assign the configuration to the appropriate plugin.
 The third argument is an array which contains all controller-action combinations
 which the plugin is authorized to execute. The specification array('Offer' =>
 'index') authorizes the plugin to perform the method indexAction() in
-Tx_SjrOffers_Controller_OfferController. Be aware that the name of the
+\MyVendor\SjrOffers\Controller\OfferController. Be aware that the name of the
 controller is writen without the suffix Controller and the name of the action
 method without the suffix Action.
 

--- a/Documentation/7-Controllers/3-Configuring-the-behavior-of-the-extension.rst
+++ b/Documentation/7-Controllers/3-Configuring-the-behavior-of-the-extension.rst
@@ -27,7 +27,7 @@ thus looks like this:
 ``public function indexAction() {``
 
 ``$this->view->assign('organizations',
-$this->organizationRepository->findByStates(t3lib_div::intExplode(',',$this->settings['allowedStates'])));``
+$this->organizationRepository->findByStates(GeneralUtility::intExplode(',',$this->settings['allowedStates'])));``
 
 ``...``
 
@@ -38,7 +38,7 @@ Method :class:`findByStates()`, which we do not further
 investigate here (see more in chapter 6, section "Implement individual
 database queries"). The Method expects an array containing the allowed
 states. We generate it from the comma seperated list using the TYPO3 API
-function :class:`t3lib_div::intExplode()`. We then pass on the
+function :class:`GeneralUtility::intExplode()`. We then pass on the
 returned choice of organizations to the view, just as we are used to
 do.
 

--- a/Documentation/8-Fluid/10-template-creation-by-example.rst
+++ b/Documentation/8-Fluid/10-template-creation-by-example.rst
@@ -66,7 +66,7 @@ necessary. The complete conent of the plugin is then "packed" in a
 message* - will be created inside our sample extension in the
 controller, e.g. at unauthorized access (see also the sections for edit and delete controller actions in :ref:`chapter 7 <controlling-the-flow-with-controllers>`)::
 
-	public function updateAction(Tx_SjrOffers_Domain_Model_Offer $offer) {
+	public function updateAction(\MyVendor\SjrOffers\Domain\Model\Offer $offer) {
 		$administrator = $offer->getOrganization()->getAdministrator();
 		if ($this->accessControlService->isLoggedIn($administrator)) {
 			...

--- a/Documentation/8-Fluid/8-developing-a-custom-viewhelper.rst
+++ b/Documentation/8-Fluid/8-developing-a-custom-viewhelper.rst
@@ -48,11 +48,11 @@ operations.
 First of all, think about how the ViewHelper should be called inside
 the template: The ViewHelper is not part of the default distribution,
 therefore we need an own namespace import to use the ViewHelper. We import
-the namespace ``Tx_BlogExample_ViewHelpers`` with the token
+the namespace ``\MyVendor\BlogExample\ViewHelpers`` with the token
 ``blog``. Now, all tags starting with ``blog:`` are
 interpreted as ViewHelper::
 
-	``{namespace blog=Tx_BlogExample_ViewHelpers}``
+	``{namespace blog=\MyVendor\BlogExample\ViewHelpers}``
 
 Our ViewHelper should get the name gravatar and only get an email
 address as parameter. We will call the ViewHelper in the template as
@@ -73,31 +73,34 @@ namespace import and the name of the XML element. The classname consists
 of the following three parts:
 
 * full namespace (in our example
-  ``Tx_BlogExample_ViewHelpers``)
+  ``\MyVendor\BlogExample\ViewHelpers``)
 * the name of the ViewHelper in UpperCamelCase writing (in our
   example ``Gravatar``)
 * the ending ``ViewHelper``
 
 For the Gravatar ViewHelper the name of the class is
-``Tx_BlogExample_ViewHelpers_GravatarViewHelper``.
+``\MyVendor\BlogExample\ViewHelpers\GravatarViewHelper``.
 
 Following the naming conventions for Extbase extensions we create
 the ViewHelper skeleton in the PHP file
 *EXT:blog_example/Classes/ViewHelpers/GravatarViewHelper.php*::
 
-	class Tx_BlogExample_ViewHelpers_GravatarViewHelper extends Tx_Fluid_Core_ViewHelper_AbstractViewHelper {
+	<?php
+	namespace \MyVendor\BlogExample\ViewHelpers;
+
+	class GravatarViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper {
 	public function render() {
 	}
 	}
 
 Every ViewHelper must inherit from the class
-``Tx_Fluid_Core_ViewHelper_AbstractViewHelper``.
+``\TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper``.
 
 .. tip::
 
 	A ViewHelper can also inherit from subclasses of
 	``AbstractViewHelper``, e.g. from
-	``Tx_Fluid_Core_ViewHelper_TagBasedViewHelper``. Several
+	``\TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper``. Several
 	subclasses are offering additional functionality. We will talk about the
 	just addressed TagBasedViewHelper later on in this chapter in detail in
 	"Creating XML tags using TagBasedViewHelper".
@@ -107,7 +110,10 @@ called once the ViewHelper is to be displayed in the template. The return
 value of the method is copied directly into the complete output. If we
 enhanced our ViewHelper from above as follows::
 
-	class Tx_BlogExample_ViewHelpers_GravatarViewHelper extends Tx_Fluid_Core_ViewHelper_AbstractViewHelper {
+	<?php
+	namespace \MyVendor\BlogExample\ViewHelpers;
+
+	class GravatarViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper {
 		public function render() {
 			return 'World';
 		}
@@ -115,7 +121,7 @@ enhanced our ViewHelper from above as follows::
 
 and we insert it in the template like this::
 
-	{namespace blog=Tx_BlogExample_ViewHelpers}
+	{namespace blog=\MyVendor\BlogExample\ViewHelpers}
 	Hello <blog:gravatar />
 
 ``Hello World`` should be displayed.
@@ -165,7 +171,10 @@ because the type of the parameter is based on this by Fluid.
 
 At the end we implement the output as img tag::
 
-	class Tx_BlogExample_ViewHelpers_GravatarViewHelper extends Tx_Fluid_Core_ViewHelper_AbstractViewHelper {
+	<?php
+	namespace \MyVendor\BlogExample\ViewHelpers;
+
+	class GravatarViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper {
 	/**
 	* @param string $emailAddress The email address to resolve the gravatar for
 	* @return string the HTML <img>-Tag of the gravatar
@@ -202,7 +211,10 @@ $defaultValue)``. You can access these arguments through the array
 The above example could be changed in the following way and would
 function identical::
 
-	class Tx_BlogExample_ViewHelpers_GravatarViewHelper extends Tx_Fluid_Core_ViewHelper_AbstractViewHelper {
+	<?php
+	namespace \MyVendor\BlogExample\ViewHelpers;
+
+	class GravatarViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper {
 	/**
 	* Arguments Initialization
 	*/
@@ -233,8 +245,8 @@ Creating XML tags using TagBasedViewHelper
 --------------------------------------------------------------------------------------------------
 
 For ViewHelper that create XML tags Fluid provides an enhanced
-baseclass: the ``Tx_Fluid_Core_TagBasedViewHelper``. This
-ViewHelper provides a *Tag-Builder* that can be used to
+baseclass: the ``\TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper``.
+This ViewHelper provides a *Tag-Builder* that can be used to
 create tags in a simple way. It takes care about the syntactical correct
 creation of the tag and escapes for example single and double quote in
 attributes.

--- a/Documentation/8-Fluid/9-using-php-based-views.rst
+++ b/Documentation/8-Fluid/9-using-php-based-views.rst
@@ -20,7 +20,7 @@ against a naming convention which is defined in the
 ``$viewObjectNamePattern``. The default naming convention is
 following::
 
-	Tx_@extension_View_@controller_@action@format
+	\MyVendor\@extension\View\@controller\@action@format
 
 All parts beginning with ``@`` will be replaced accordingly.
 When no class with this name can be found, the ``@format`` will be
@@ -28,22 +28,25 @@ removed from the naming convention and a matching class again searched
 for.
 
 Our PHP based view for the list view of the post controller should
-have the class name ``Tx_BlogExample_view_Post_ListJSON``, because
+have the class name ``\MyVendor\BlogExample\View\Post\ListJSON``, because
 it applies only for the format JSON. So that the class according to the
 naming convention must be implemented in the file
 *EXT:blog_example/Classes/View/Post/ListJSON.php*.
 
 Each view must implement the interface
-``Tx_Extbase_MVC_View_ViewInterface``. This consists off some
+``\TYPO3\CMS\Extbase\Mvc\ViewViewInterface``. This consists off some
 initializing methods and the ``render()`` method, which is called
 by the controller for displaying the view.
 
 It is often helpful to inherit directly from
-``Tx_Extbase_MVC_View_AbstractView`` which provides default
+``\TYPO3\CMS\Extbase\Mvc\View\AbstractView`` which provides default
 initializing methods and you only have to implement the
 ``render()`` method. A minimal view would like this::
 
-	class Tx_BlogExample_View_Post_ListJSON extends Tx_Extbase_MVC_View_AbstractView {
+	<?php
+	namespace \MyVendor\BlogExample\View\Post;
+
+	class ListJSON extends \TYPO3\CMS\Extbase\Mvc\View\AbstractView {
 		public function render() {
 			return 'Hello World';
 		}
@@ -53,7 +56,10 @@ Now we have the full expression power of PHP available and we can
 implement our own output logic. For example our JSON view could look like
 this::
 
-	class Tx_BlogExample_View_Post_ListJSON extends Tx_Extbase_MVC_View_AbstractView {
+	<?php
+	namespace \MyVendor\BlogExample\View\Post;
+
+	class ListJSON extends \TYPO3\CMS\Extbase\Mvc\View\AbstractView {
 		public function render() {
 			$postList = $this->viewData['posts'];
 			return json_encode($postList);
@@ -88,7 +94,7 @@ view.
 If you want to control the resolving and initializing of the view
 completely, you have to rewrite the method ``resolveView()``.
 This method has to return a view that implements
-``Tx_Extbase_MVC_ViewInterface``. Sometimes it is enough to just
+``\TYPO3\CMS\Extbase\Mvc\ViewViewInterface``. Sometimes it is enough to just
 overwrite the resolution of the view object name. Therefore you must
 overwrite the method ``resolveViewObjectName()``. This method
 returns the name of the PHP class which should be used as view.

--- a/Documentation/9-CrosscuttingConcerns/2-validating-domain-objects.rst
+++ b/Documentation/9-CrosscuttingConcerns/2-validating-domain-objects.rst
@@ -39,7 +39,7 @@ A validator is a PHP class that has to check a certain invariant. If
 the invariant is fulfilled than the validator returns ``true``
 otherwise ``false``. In Extbase all validators have to implement
 the interface
-:class:`Tx_Extbase_Validation_Validator_ValidatorInterface`.
+:class:`\TYPO3\CMS\Extbase\Validation\Validator\ValidatorInterface`.
 In this interface some methods are defined. The most important is called
 ``isValid($object)``. An object or value is passed over to it and
 it must return ``true`` when the object or value is valid,
@@ -47,7 +47,7 @@ otherwise it returns ``false``. There are some more methods in
 the :class:`ValidatorInterface` to make it possible to pass
 settings and poll error messages. We recommend to inherit all validators
 from the
-:class:`Tx_Extbase_Validation_Validator_AbstractValidator`,
+:class:`\TYPO3\CMS\Extbase\Validation\Validator\AbstractValidator`,
 because you get a default implemetation of the helper methods and you only
 have to implement the `isValid()` method.
 
@@ -91,7 +91,7 @@ empty. This is configued through the property ``$acceptsEmptyValues`` which is
 set to ``true`` as default.
 
 In the package
-:class:`Tx_Extbase_Validation_Validator_*` Extbase offers
+:class:`\TYPO3\CMS\Extbase\Validation\Validator\*` Extbase offers
 many validators for default requirements like the validation of emails,
 numbers or strings.
 
@@ -177,7 +177,10 @@ available. With it we can specify which validator is to be used for
 checking the annotated property. Let us take a look at this using a part
 of the domain model ``Post`` of the blog example::
 
-    class Tx_BlogExample_Domain_Model_Post extends Tx_Extbase_DomainObject_AbstractEntity {
+    <?php
+    namespace \MyVendor\BlogExample\Domain\Model;
+
+    class Post extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity {
         /**
          * @var string
          * @validate StringLength(minimum=3, maximum=50)
@@ -198,20 +201,23 @@ than three characters and will never be longer than 50 characters.
 
 Which validator class is to be used? Extbase looks for a validator
 class using
-``Tx_Extbase_Validation_Validator_*ValidatorName*Validator``.
+``\TYPO3\CMS\Extbase\Validation\Validator\*ValidatorName*Validator``.
 Using the above given annotation ``@validate StringLength`` the
 validator
-:class:`Tx_Extbase_Validation_Validator_StringLengthValidator`
+:class:`\TYPO3\CMS\Extbase\Validation\Validator\StringLengthValidator`
 is used.
 
 When you have created your own validator to check the invariants
 you can use it in the ``@validate`` annotation using the full
 class name, like shown in the following example::
 
-    class Tx_BlogExample_Domain_Model_Post extends Tx_Extbase_DomainObject_AbstractEntity {
+    <?php
+    namespace \MyVendor\BlogExample\Domain\Model;
+
+    class Post extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity {
         /**
          * @var string
-         * @validate Tx_BlogExample_Domain_Validator_TitleValidator
+         * @validate \MyVendor\BlogExample\Domain\Validator\TitleValidator
          */
         protected $title;
 
@@ -222,7 +228,7 @@ class name, like shown in the following example::
     }
 
 Here we validate the property ``$title`` with the
-:class:`Tx_BlogExample_Domain_Validator_TitleValidator`.
+:class:`\MyVendor\BlogExample\Domain\Validator\TitleValidator`.
 This validator class now can check any invariants. For example, the
 validator shown in the following listing checks whether the title of a
 blog post is always build-on the scheme *Maintopic:
@@ -256,9 +262,9 @@ access to all object properties is possible.
 
 Important hereby is the correct naming convention. If you need a
 validator for the class
-:class:`Tx_ExtbaseExample_Domain_Model_User` it must be
+:class:`\MyVendor\ExtbaseExample\Domain\Model\User` it must be
 implemented in the class
-:class:`Tx_ExtbaseExample_Domain_Validator_UserValidator`.
+:class:`\MyVendor\ExtbaseExample\Domain\Validator\UserValidator`.
 The name of the validator for a model object is incidental by replacing
 the namespace ``Model`` with ``Validator`` and also
 append ``Validator``. When following the naming convention the
@@ -271,9 +277,12 @@ object is of the type ``user`` - after all the validator can be
 called with any object and has to return ``false`` in such
 case::
 
-    class Tx_ExtbaseExample_Domain_Validator_UserValidator extends Tx_Extbase_Validation_Validator_AbstractValidator {
+    <?php
+    namespace \MyVendor\ExtbaseExample\Domain\Validator;
+
+    class UserValidator extends \TYPO3\CMS\Extbase\Validation\Validator\AbstractValidator {
         public function isValid($user) {
-            if (! $user instanceof Tx_ExtbaseExample_Domain_Model_User) {
+            if (! $user instanceof \MyVendor\ExtbaseExample\Domain\Model\User) {
                 $this->addError('The given Object is not a User.', 1262341470);
                 return FALSE;
             }
@@ -298,9 +307,12 @@ Now we have created the foundation of our validator and can start
 with the proper implementation - the check for equality of the
 passwords. This is made quickly::
 
-    class Tx_ExtbaseExample_Domain_Validator_UserValidator extends Tx_Extbase_Validation_Validator_AbstractValidator {
+    <?php
+    namespace \MyVendor\ExtbaseExample\Domain\Validator;
+
+    class UserValidator extends \TYPO3\CMS\Extbase\Validation\Validator\AbstractValidator {
         public function isValid($user) {
-            if (! $user instanceof Tx_ExtbaseExample_Domain_Model_User) {
+            if (! $user instanceof \MyVendor\ExtbaseExample\Domain\Model\User) {
                 $this->addError('The given Object is not a User.', 1262341470);
                 return FALSE;
             }
@@ -338,13 +350,13 @@ Therefore a slightly modified form of the ``@validate``
 annotation can be used which is set in the comment block of the
 controller action. It has the format ``@validate
 *[variablename] [validators]*``, in the example
-below it is ``$pageName`` :class:`Tx_MyExtension_Domain_Validator_PagenameValidator`::
+below it is ``$pageName`` :class:`\MyVendor\MyExtension\Domain\Validator\PagenameValidator`::
 
     /**
      * Creates a new page with a given name.
      *
      * @param string $pageName THe name of the page which should be created.
-     * @validate $pageName Tx_MyExtension_Domain_Validator_PageNameValidator
+     * @validate $pageName \MyVendor\MyExtension\Domain\Validator\PageNameValidator
      */
     public function createPageAction($pageName) {
         ...
@@ -378,10 +390,10 @@ example::
      * Creates a website user for the given page name.
      *
      * @param string $pageName The name of the page where the user should be created.
-     * @param Tx_ExtbaseExample_Domain_Model_User $user The user which should be created.
-     * @validate $user Tx_BlogExample_Domain_Validator_CustomUserValidator
+     * @param \MyVendor\ExtbaseExample\Domain\Model\User $user The user which should be created.
+     * @validate $user \MyVendor\BlogExample\Domain\Validator\CustomUserValidator
      */
-    public function createUserAction($pageName, Tx_ExtbaseExample_Domain_Model_User $user) {
+    public function createUserAction($pageName, \MyVendor\ExtbaseExample\Domain\Model\User $user) {
         ...
     }
 
@@ -389,9 +401,9 @@ Here the following things are validated: ``$pageName``
 must be a *string*. The data type of the
 ``@param`` annotation is validated. For ``$user`` all
 ``@validate`` annotations of the model are validated. Also the
-``Tx_BlogExample_Domain_Validator_UserValidator`` is called if
+``\MyVendor\BlogExample\Domain\Validator\UserValidator`` is called if
 it exists. Beyond that the validator
-``Tx_BlogExample_Domain_Validator_CustomUserValidator`` is used
+``\MyVendor\BlogExample\Domain\Validator\CustomUserValidator`` is used
 to validate ``$user``.
 
 In some use cases it is reasonable that *inconsistent
@@ -422,7 +434,7 @@ validation error. Two actions are involved at editing the blog: The
 
 The ``editAction`` for the blog looks like this::
 
-    public function editAction(Tx_BlogExample_Domain_Model_Blog $blog) {
+    public function editAction(\MyVendor\BlogExample\Domain\Model\Blog $blog) {
         $this->view->assign('blog', $blog);
     }
 
@@ -448,7 +460,7 @@ as parameter.
 
 ::
 
-    public function updateAction((Tx_BlogExample_Domain_Model_Blog $blog) {
+    public function updateAction((\MyVendor\BlogExample\Domain\Model\Blog $blog) {
         $this->blogRepository->update($blog);
     }
 
@@ -481,10 +493,10 @@ annotation ``@dontvalidate ``- the comment block of the
 ``editAction`` must be changed like this::
 
     /**
-     * @param Tx_BlogExample_Domain_Model_Blog $blog The blog object
+     * @param \MyVendor\BlogExample\Domain\Model\Blog $blog The blog object
      * @dontvalidate $blog
      */
-    public function editAction(Tx_BlogExample_Domain_Model_Blog $blog) {
+    public function editAction(\MyVendor\BlogExample\Domain\Model\Blog $blog) {
         $this->view->assign('blog', $blog);
     }
 
@@ -495,7 +507,7 @@ displayed correct.
 .. tip::
 
     If Extbase thows the exception
-    Tx_Extbase_MVC_Exception_InfiniteLoop it signs that the
+    \TYPO3\CMS\Extbase\Mvc\Exception\InfiniteLoopException it signs that the
     ``@dontvalidate`` annotation is missing.
 
 Fluid automatically adds the CSS class ``f3-form-error``
@@ -526,19 +538,19 @@ code::
     /**
      * This action shows the 'new' form for the blog.
      *
-     * @param Tx_BlogExample_Domain_Model_Blog $newBlog The optional default values
+     * @param \MyVendor\BlogExample\Domain\Model\Blog $newBlog The optional default values
      * @dontvalidate $newBlog
      */
-    public function newAction(Tx_BlogExample_Domain_Model_Blog $newBlog = NULL) {
+    public function newAction(\MyVendor\BlogExample\Domain\Model\Blog $newBlog = NULL) {
         $this->view->assign('newBlog', $newBlog);
     }
 
     /**
      * This action creates the blog and stores it.
      *
-     * @param Tx_BlogExample_Domain_Model_Blog $newBlog
+     * @param \MyVendor\BlogExample\Domain\Model\Blog $newBlog
      */
-    public function createAction(Tx_BlogExample_Domain_Model_Blog $newBlog) {
+    public function createAction(\MyVendor\BlogExample\Domain\Model\Blog $newBlog) {
         $this->blogRepository->add($newBlog);
     }
 
@@ -675,7 +687,7 @@ object: The changes are stored permanent now.
     this case an empty controller would be updating persistent
     objects::
 
-        public function updateAction(Tx_BlogExample_Domain_Model_Blog $blog) {
+        public function updateAction(\MyVendor\BlogExample\Domain\Model\Blog $blog) {
             // object will be automaticly persisted
         }
 


### PR DESCRIPTION
This change removes most of the old Underscore-cased classNames that have long been replaced by proper PHP namespaces. Furthermore outdated TYPO3 classnames were updated to the current TYPO3 equivalent as well.