### PR TITLE
Persistence class mapping without leading \ in namespace

### DIFF
--- a/Documentation/6-Persistence/4-use-foreign-data-sources.rst
+++ b/Documentation/6-Persistence/4-use-foreign-data-sources.rst
@@ -20,7 +20,7 @@ enables the storage of the object data of a class ``\MyVendor\MyExtension\Domain
     plugin.tx_myextension {
         persistence {
             classes {
-                \MyVendor\MyExtension\Domain\Model\Person {
+                MyVendor\MyExtension\Domain\Model\Person {
                     mapping {
                         tableName = tt_address
                         recordType = \MyVendor\MyExtension\Domain\Model\Person


### PR DESCRIPTION
Removing leading \ from namespace in persistence class mapping demonstration