### PR TITLE
Fix syntax error in code example

### DIFF
--- a/Documentation/4-FirstExtension/3-create-the-domain-model.rst
+++ b/Documentation/4-FirstExtension/3-create-the-domain-model.rst
@@ -28,7 +28,7 @@ from the extbase class
 :php:`\TYPO3\CMS\Extbase\DomainObject\AbstractEntity`. ::
 
     <?php
-    namespace \MyVendor\Inventory\Domain\Model\;
+    namespace \MyVendor\Inventory\Domain\Model;
 
     use \TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 


### PR DESCRIPTION
Having a backslash at the end accidentally escapes the semicolon instead of being a proper identifier.