### PR TITLE
Fix documentation for Extbase language handling on creating new records

### DIFF
--- a/Documentation/9-CrosscuttingConcerns/1-localizing-and-internationalizing-an-extension.rst
+++ b/Documentation/9-CrosscuttingConcerns/1-localizing-and-internationalizing-an-extension.rst
@@ -380,9 +380,8 @@ objects in the frontend.*
 |Editing (edit,   |Like displaying an object. The domain data is stored in the "translated"|
 |update)          |data record, in the above example in the record with the UID 42.        |
 +-----------------+------------------------------------------------------------------------+
-|Creation (new,   |Independent of the selected frontend language the domain object is first|
-|create)          |marked valid for all languages. The data is stored in a new record in   |
-|                 |whose field ``sys_language_uid`` the number -1 is inserted.             |
+|Creation (new,   |Independent of the selected frontend language the data is stored in a   |
+|create)          |new record in whose field ``sys_language_uid`` the number 0 is inserted.|
 +-----------------+-----------------------------------+------------------------------------+
 
 Extbase also supports all default functions of the localization of


### PR DESCRIPTION
The core team decided, that the default language when creating a new record with Extbase is 0 and not -1 or the the current frontend language. https://review.typo3.org/#/c/41595/