### PR TITLE
TASK: Add non documented extbase typoscript feature option

### DIFF
--- a/Documentation/b-ExtbaseReference/Index.rst
+++ b/Documentation/b-ExtbaseReference/Index.rst
@@ -199,6 +199,7 @@ the following sections:
 .. _typoscript_configuration-features:
 .. _features-skipDefaultArguments:
 .. _features-ignoreAllEnableFieldsInBe:
+.. _features-requireCHashArgumentForActionArguments:
 
 features
 --------
@@ -213,6 +214,13 @@ Activate features for Extbase or a specific plugin.
 `features.ignoreAllEnableFieldsInBe`
     Ignore the enable fields in backend.
     Default is `false`.
+
+`features.requireCHashArgumentForActionArguments`
+    Only available below `config.tx_extbase`, not for individual plugins!
+
+    Do not force a cHash for arguments used in actions. If this is turned on, all requests with
+    arguments but no, or an invalid cHash, are handled as `pageNotFoundOnCHashError`.
+    Default is `true`.
 
 .. _typoscript_configuration-persistence:
 .. _persistence-enableAutomaticCacheClearing:


### PR DESCRIPTION
Add documentation for feature option pageNotFoundOnCHashError, available
via TypoScript.