### PR TITLE
Add tip to re-installation of extension

### DIFF
--- a/Documentation/10-Outlook/3-Command-controllers.rst
+++ b/Documentation/10-Outlook/3-Command-controllers.rst
@@ -56,8 +56,9 @@ After creation of the controller you need to register it. Add the following line
 Calling commands
 ----------------
 
-Once a command is registered and available, you can check the availability by calling
-`typo3/cli_dispatch.phpsh extbase help`.
+Re-install your extension to complete the registration. Once a command is registered and available, you can check the availability by calling
+`
+/cli_dispatch.phpsh extbase help`.
 
 The output should look like::
 

--- a/Documentation/10-Outlook/3-Command-controllers.rst
+++ b/Documentation/10-Outlook/3-Command-controllers.rst
@@ -56,7 +56,7 @@ After creation of the controller you need to register it. Add the following line
 Calling commands
 ----------------
 
-Re-install your extension to complete the registration. Once a command is registered and available, you can check the availability by calling
+Clear the backend-cache to complete the registration. Once a command is registered and available, you can check the availability by calling
 `
 /cli_dispatch.phpsh extbase help`.
 


### PR DESCRIPTION
Especially for beginners it is important to mention that the extension has to be re-installed so that the controller is available on the CLI.