### PR TITLE
TASK: Fix $_EXTKEY usage in docs

### DIFF
--- a/Documentation/10-Outlook/2-Backend-modules.rst
+++ b/Documentation/10-Outlook/2-Backend-modules.rst
@@ -15,7 +15,7 @@ root directory of our extension. Lets look at our blog example how it defines a 
 
     if (TYPO3_MODE === 'BE') {
         \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
-            'Vendor.ext_key',
+            'Vendor.ExtensionName',
             'web',          // Main area
             'mod1',         // Name of the module
             '',             // Position of the module

--- a/Documentation/10-Outlook/2-Backend-modules.rst
+++ b/Documentation/10-Outlook/2-Backend-modules.rst
@@ -15,7 +15,7 @@ root directory of our extension. Lets look at our blog example how it defines a 
 
     if (TYPO3_MODE === 'BE') {
         \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
-            'Vendor' . $_EXTKEY,
+            'Vendor.ext_key',
             'web',          // Main area
             'mod1',         // Name of the module
             '',             // Position of the module
@@ -27,7 +27,7 @@ root directory of our extension. Lets look at our blog example how it defines a 
             array(          // Additional configuration
                 'access'    => 'user,group',
                 'icon'      => 'EXT:blog_example/ext_icon.gif',
-                'labels'    => 'LLL:EXT:' . $_EXTKEY . '/Resources/Private/Language/locallang_mod.xml',
+                'labels'    => 'LLL:EXT:ext_key/Resources/Private/Language/locallang_mod.xml',
             )
         );
     }

--- a/Documentation/10-Outlook/3-Command-controllers.rst
+++ b/Documentation/10-Outlook/3-Command-controllers.rst
@@ -47,7 +47,7 @@ After creation of the controller you need to register it. Add the following line
     <?php
 
     if (TYPO3_MODE === 'BE') {
-        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['extbase']['commandControllers']['ext_key'] =
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['extbase']['commandControllers']['ExtensionName-MeaningFullName'] =
             \Vendor\ExtKey\Command\SimpleCommandController::class;
     }
 

--- a/Documentation/10-Outlook/3-Command-controllers.rst
+++ b/Documentation/10-Outlook/3-Command-controllers.rst
@@ -47,8 +47,8 @@ After creation of the controller you need to register it. Add the following line
     <?php
 
     if (TYPO3_MODE === 'BE') {
-        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['extbase']['commandControllers'][$_EXTKEY] =
-            \Vendor\Example\Command\SimpleCommandController::class;
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['extbase']['commandControllers']['ext_key'] =
+            \Vendor\ExtKey\Command\SimpleCommandController::class;
     }
 
 .. _extbase_command_controller_calling:

--- a/Documentation/4-FirstExtension/2-create-folder-structure-and-configuration-files.rst
+++ b/Documentation/4-FirstExtension/2-create-folder-structure-and-configuration-files.rst
@@ -69,7 +69,7 @@ extension. Find a complete reference in chapter
 
 	<?php
 
-	$EM_CONF[$_EXTKEY] = [
+	$EM_CONF['ext_key'] = [
 		'title' => 'Store Inventory',
 		'description' => 'An extension to manage a stock.',
 		'category' => 'plugin',

--- a/Documentation/4-FirstExtension/2-create-folder-structure-and-configuration-files.rst
+++ b/Documentation/4-FirstExtension/2-create-folder-structure-and-configuration-files.rst
@@ -69,7 +69,7 @@ extension. Find a complete reference in chapter
 
 	<?php
 
-	$EM_CONF['ext_key'] = [
+	$EM_CONF[$_EXTKEY] = [
 		'title' => 'Store Inventory',
 		'description' => 'An extension to manage a stock.',
 		'category' => 'plugin',

--- a/Documentation/4-FirstExtension/7-configuring-the-plugin.rst
+++ b/Documentation/4-FirstExtension/7-configuring-the-plugin.rst
@@ -29,9 +29,10 @@ create in the top level of our extension directory.
     );
 
 With the first line we prevent of security reasons, that the PHP code can be
-called directly outside of TYPO3.  The static method ``configurePlugin()`` of
-the class offers several arguments.  With the first we assign the extension key
-(it follows from the name of the extension directory) prefixed by the vendor
+called directly outside of TYPO3.  The static method
+:php:`\TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin()` of the class
+offers several arguments.  With the first we assign the extension key (it
+follows from the name of the extension directory) prefixed by the vendor
 namespace followed by a dot. This indicates, that we use namespaces for our php
 classes.  With the second argument we give an unique name for the plugin (in
 UpperCamelCase notation).  Because of historical reasons there is often used

--- a/Documentation/4-FirstExtension/7-configuring-the-plugin.rst
+++ b/Documentation/4-FirstExtension/7-configuring-the-plugin.rst
@@ -28,13 +28,15 @@ create in the top level of our extension directory.
         ]
     );
 
-With the first line we prevent of security reasons, that the PHP code can be called directly outside of TYPO3.
-The static method ``configurePlugin()`` of the class offers several arguments.
-With the first we assign the extension key, which stand by in the global variable
-``$EXTKEY`` (it follows from the name of the extension directory) prefixed by the vendor namespace followed by a dot. This indicates, that we use namespaces for our php classes.
-With the second argument we give an unique name for the plugin (in UpperCamelCase notation).
-Because of historical reasons there is often used ``Pi1``, but maybe it is better to use more meaningfull
-names like "InventoryList".
+With the first line we prevent of security reasons, that the PHP code can be
+called directly outside of TYPO3.  The static method ``configurePlugin()`` of
+the class offers several arguments.  With the first we assign the extension key
+(it follows from the name of the extension directory) prefixed by the vendor
+namespace followed by a dot. This indicates, that we use namespaces for our php
+classes.  With the second argument we give an unique name for the plugin (in
+UpperCamelCase notation).  Because of historical reasons there is often used
+``Pi1``, but maybe it is better to use more meaningfull names like
+"InventoryList".
 This is used later to clearly identify the plugin amongst other plugins on the page.
 The third argument is an array with all controller action combinations, the plugin
 can execute. The array key is the name of the controller (without the suffix ``Controller``)

--- a/Documentation/7-Controllers/2-Configuring-and-embedding-Frontend-Plugins.rst
+++ b/Documentation/7-Controllers/2-Configuring-and-embedding-Frontend-Plugins.rst
@@ -17,10 +17,10 @@ a content element with Typo3 using the static method registerPlugin().
 <remark>TODO:code</remark>
 
 The method registerPlugin() expects three argumets. The first argument is the
-extension key (sjr_offers in our example). This key is available in TYPO3's
-global variable $_EXTKEY and is the same as the directory name of the extension.
+extension key (sjr_offers in our example). This key is the same as the directory
+name of the extension.
 The second parameter is a freely selectable name of the plugin (a short,
-meaningful name in UpperCAmelCase). The plugin name plays a significant role in
+meaningful name in UpperCamelCase). The plugin name plays a significant role in
 the allocation of GET- and POST parameters to the appropriate plugin:
 http://localhost/index.php?id=123&ts_sjroffers_list[offer]=3. The third argument
 is the label by which the plugin appears in the list of plugin in the backend.

--- a/Documentation/b-ExtbaseReference/Index.rst
+++ b/Documentation/b-ExtbaseReference/Index.rst
@@ -50,7 +50,7 @@ backend. Let's have a look at the following two files:
 
     $pluginName = 'ExamplePlugin';
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-        'Vendor.ext_key',
+        'Vendor.ExtensionName',
         $pluginName,
         $controllerActionCombinations,
         $uncachedActions
@@ -95,7 +95,7 @@ frontend plugin within the files :file:`ext_localconf.php` and :file:`Configurat
 
     $pluginName = 'Blog';
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-        'Vendor.ext_key',
+        'Vendor.ExtensionName',
         $pluginName,
         [
             'Blog' => 'index,show,new,create,delete,deleteAll,edit,update,populate',

--- a/Documentation/b-ExtbaseReference/Index.rst
+++ b/Documentation/b-ExtbaseReference/Index.rst
@@ -50,7 +50,7 @@ backend. Let's have a look at the following two files:
 
     $pluginName = 'ExamplePlugin';
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-        'Vendor.' . $_EXTKEY,
+        'Vendor.ext_key',
         $pluginName,
         $controllerActionCombinations,
         $uncachedActions
@@ -80,14 +80,11 @@ same format as above, containing all the non-cached-actions.
         $pluginIcon
     );
 
-The extension key (`$extensionKey` or `$_EXTKEY`) and `$pluginName` must be completely identical to the definition
-in :file:`ext_localconf.php`. `$extensionKey` must be filled with the extension key by yourself, where `$_EXTKEY` is not available. `$backendTitle` defines the displayed name of the plugin in
-the Backend.
-
-.. note::
-
-   **Attention:** The variable :php:`$_EXTKEY` is not available in the directory :file:`Configuration/TCA/`,
-   so you have to fill in your extension key directly.
+The extension key (`$extensionKey` or `example_extensionkey`) and `$pluginName`
+must be completely identical to the definition in :file:`ext_localconf.php`.
+`$extensionKey` must be filled with the extension key by
+yourself.`$backendTitle` defines the displayed name of the plugin in the
+Backend.
 
 Below there is a complete configuration example for the registration of a
 frontend plugin within the files :file:`ext_localconf.php` and :file:`Configuration/TCA/Overrides/tt_content.php`.
@@ -98,7 +95,7 @@ frontend plugin within the files :file:`ext_localconf.php` and :file:`Configurat
 
     $pluginName = 'Blog';
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-        'Vendor.' . $_EXTKEY,
+        'Vendor.ext_key',
         $pluginName,
         [
             'Blog' => 'index,show,new,create,delete,deleteAll,edit,update,populate',

--- a/Documentation/b-ExtbaseReference/Index.rst
+++ b/Documentation/b-ExtbaseReference/Index.rst
@@ -71,20 +71,14 @@ same format as above, containing all the non-cached-actions.
 
 .. code-block:: php
 
-    $extensionKey = 'example_extensionkey';
-    $pluginName = 'ExamplePlugin';
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-        'Vendor.' . $extensionKey,
-        $pluginName,
-        $backendTitle,
-        $pluginIcon
+        'Vendor.ExtensionName',
+        'ExamplePlugin',
+        'Title used in Backend'
     );
 
-The extension key (`$extensionKey` or `example_extensionkey`) and `$pluginName`
-must be completely identical to the definition in :file:`ext_localconf.php`.
-`$extensionKey` must be filled with the extension key by
-yourself.`$backendTitle` defines the displayed name of the plugin in the
-Backend.
+The first two arguments must be completely identical to the definition in
+:file:`ext_localconf.php`.
 
 Below there is a complete configuration example for the registration of a
 frontend plugin within the files :file:`ext_localconf.php` and :file:`Configuration/TCA/Overrides/tt_content.php`.
@@ -93,10 +87,9 @@ frontend plugin within the files :file:`ext_localconf.php` and :file:`Configurat
 
 .. code-block:: php
 
-    $pluginName = 'Blog';
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-        'Vendor.ExtensionName',
-        $pluginName,
+        'Vendor.ExampleExtension',
+        'Blog',
         [
             'Blog' => 'index,show,new,create,delete,deleteAll,edit,update,populate',
             'Post' => 'index,show,new,create,delete,edit,update',
@@ -113,22 +106,24 @@ frontend plugin within the files :file:`ext_localconf.php` and :file:`Configurat
 
 .. code-block:: php
 
-    $extensionKey = 'example_extensionkey';
-    $pluginName = 'Blog';
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-        'Vendor.' . $extensionKey,
-        $pluginName,
+        'Vendor.ExampleExtension',
+        'Blog',
         'A Blog Example',
         'EXT:blog/Resources/Public/Icons/Extension.svg'
     );
 
-The plugin name (`$pluginName`) is ``Blog``. It is important that the name is exactly the same in
-:file:`ext_localconf.php` and :file:`Configuration/TCA/Overrides/tt_content.php`. The default action is ``index`` of controller
-``blog`` since it's the first element defined in the array and the first action in the list.
+The plugin name is ``Blog``. It is important that the name is exactly the same
+in :file:`ext_localconf.php` and
+:file:`Configuration/TCA/Overrides/tt_content.php`. The default called method is
+:php:`indexAction()` of controller class
+:php:`Vendor\ExampleExtension\Controller\BlogController` since it's the first
+element defined in the array and the first action in the list.
 
 All actions which change data must not be cacheable. Above, this is for example
-the ``delete`` action in the ``blog`` controller. In the backend you can see "*A Blog
-Example*" in the list of plugins (see Figure B-1).
+the :php:`deleteAction()` action in the
+:php:`Vendor\ExampleExtension\Controller\BlogController` controller. In the
+backend you can see "*A Blog Example*" in the list of plugins (see Figure B-1).
 
 .. figure:: /Images/b-ExtbaseReference/figure-b-1.png
     :align: center


### PR DESCRIPTION
As $_EXTKEY is more or less deprecated and will be removed in the
future. It's recommended to use the extension key as a string.

Therefore all examples were adjusted, including all mentions of the
variable.