### PR TITLE
Fixed TypoScript-Configuration

### DIFF
--- a/Documentation/6-Persistence/5-modeling-the-class-hierarchy.rst
+++ b/Documentation/6-Persistence/5-modeling-the-class-hierarchy.rst
@@ -91,7 +91,7 @@ data of the instances are stored and with which type they should be stored.
         MyVendor\MyExtension\Domain\Model\Organization {
             mapping {
                 tableName = tx_myextension_domain_model_party
-                recordType = \MyVendor\MyExtension\Domain\Model\Organization
+                recordType = MyVendor\MyExtension\Domain\Model\Organization
             }
             subclasses {
                 \MyVendor\MyExtension\Domain\Model\Company = MyVendor\MyExtension\Domain\Model\Company

--- a/Documentation/6-Persistence/5-modeling-the-class-hierarchy.rst
+++ b/Documentation/6-Persistence/5-modeling-the-class-hierarchy.rst
@@ -88,29 +88,29 @@ data of the instances are stored and with which type they should be stored.
 .. code-block:: typoscript
 
     config.tx_extbase.persistence.classes {
-        \MyVendor\MyExtension\Domain\Model\Organization {
+        MyVendor\MyExtension\Domain\Model\Organization {
             mapping {
                 tableName = tx_myextension_domain_model_party
                 recordType = \MyVendor\MyExtension\Domain\Model\Organization
             }
             subclasses {
-                \MyVendor\MyExtension\Domain\Model\Company = \MyVendor\MyExtension\Domain\Model\Company
-                \MyVendor\MyExtension\Domain\Model\ScientificInstitution = \MyVendor\MyExtension\Domain\Model\ScientificInstitution
+                \MyVendor\MyExtension\Domain\Model\Company = MyVendor\MyExtension\Domain\Model\Company
+                \MyVendor\MyExtension\Domain\Model\ScientificInstitution = MyVendor\MyExtension\Domain\Model\ScientificInstitution
             }
         }
-        \MyVendor\MyExtension\Domain\Model\Person {
+        MyVendor\MyExtension\Domain\Model\Person {
             mapping {
                 tableName = tx_myextension_domain_model_party
                 recordType = \MyVendor\MyExtension\Domain\Model\Person
             }
         }
-        \MyVendor\MyExtension\Domain\Model\Company {
+        MyVendor\MyExtension\Domain\Model\Company {
             mapping {
                 tableName = tx_myextension_domain_model_party
                 recordType = \MyVendor\MyExtension\Domain\Model\Company
             }
         }
-        \MyVendor\MyExtension\Domain\Model\ScientificInstitution {
+        MyVendor\MyExtension\Domain\Model\ScientificInstitution {
             mapping {
                 tableName = tx_myextension_domain_model_party
                 recordType = \MyVendor\MyExtension\Domain\Model\ScientificInstitution


### PR DESCRIPTION
[Section: Modeling the Class Hierarchy, Topic: Single Table Inheritance]

Removed prefixed \ (backslashes) of classnames on TS-configuration "config.tx_extbase.persistence.classes" otherwise it does not work.

(TYPO3 CMS v8.7.19)