### PR TITLE
Replace @lazy with doctrine annotation

### DIFF
--- a/Documentation/5-Domain/2-implementing-the-domain-model.rst
+++ b/Documentation/5-Domain/2-implementing-the-domain-model.rst
@@ -341,20 +341,20 @@ then draw on the methods of the ObjectStorage to individual contacts.
 The property offers, we proceed to the equivalent property contacts. The
 definition of the property offers includes in the comment two special
 annotations:
-@lazy and @cascade remove.
+@TYPO3\CMS\Extbase\Annotation\ORM\Lazy and @cascade remove.
 
 .. code-block:: php
 
    /**
     * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\MyVendor\SjrOffers\Domain\Model\Offer> The offers the organization has to offer
-    * @lazy
+    * @TYPO3\CMS\Extbase\Annotation\ORM\Lazy
     * @cascade remove
     */
    protected $offers;
 
 By default Extbase invites all child objects with the parent object (so for
 example all offers of an organization). This behavior is called Eager-Loading.
-The annotation @lazy causes Extbase to load the objects and build only when they
+The annotation @TYPO3\CMS\Extbase\Annotation\ORM\Lazy causes Extbase to load the objects and build only when they
 are actually needed (lazy loading). This can be an appropriate data structure,
 e.g. many organizations, each with very many offers, that lead to a significant
 increase in speed.
@@ -362,7 +362,7 @@ increase in speed.
 .. note::
 
    Beware, however, against all the properties provided by child objects with
-   @lazy, because this can lead to frequent loading of child objects. The ensuing,
+   @TYPO3\CMS\Extbase\Annotation\ORM\Lazy, because this can lead to frequent loading of child objects. The ensuing,
    small-scaled database accesses reduces the performance and cause then the exact
    opposite of what you wanted to achieve with the lazy-loading.
 


### PR DESCRIPTION
Because of Feature #83078 the @lazy annotation is deprecated and has to be replaced with @TYPO3\CMS\Extbase\Annotation\ORM\Lazy