### PR TITLE
CompileWithRenderStatic

### DIFF
--- a/Documentation/8-Fluid/8-developing-a-custom-viewhelper.rst
+++ b/Documentation/8-Fluid/8-developing-a-custom-viewhelper.rst
@@ -51,7 +51,7 @@ address as parameter. The ViewHelper is called in the template as follows:
 
    <blog:gravatar emailAddress="username@example.com" />
 
-See :ref:`importing-namespaces-globally` for information how to import
+See :ref:`global-namespace-import` for information how to import
 namespaces globally.
 
 .. _now-implementing:
@@ -84,6 +84,13 @@ is created in the PHP file :file:`EXT:blog_example/Classes/ViewHelpers/GravatarV
           // Implementation ...
       }
    }
+
+.. note::
+
+   The method :php:`renderStatic()` requires a :php:`use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;` at 
+   the beginning of the ViewHelper class file and additionally a :php:`use CompileWithRenderStatic;` inside of the ViewHelper class.
+   Otherwise the method :php:`render()` would not be found.
+   In the future, this should no longer be necessary.
 
 Every ViewHelper must inherit from the class
 :php:`\TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper`.

--- a/Documentation/8-Fluid/8-developing-a-custom-viewhelper.rst
+++ b/Documentation/8-Fluid/8-developing-a-custom-viewhelper.rst
@@ -69,13 +69,10 @@ is created in the PHP file :file:`EXT:blog_example/Classes/ViewHelpers/GravatarV
    namespace MyVendor\BlogExample\ViewHelpers;
 
    use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
-   use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
    use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
    class GravatarViewHelper extends AbstractViewHelper
    {
-      use CompileWithRenderStatic;
-
       public static function renderStatic(
           array $arguments,
           \Closure $renderChildrenClosure,
@@ -87,10 +84,9 @@ is created in the PHP file :file:`EXT:blog_example/Classes/ViewHelpers/GravatarV
 
 .. note::
 
-   The method :php:`renderStatic()` requires a :php:`use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;` at 
+   Prior to Fluid 2.4, the method :php:`renderStatic()` required a :php:`use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;` at
    the beginning of the ViewHelper class file and additionally a :php:`use CompileWithRenderStatic;` inside of the ViewHelper class.
-   Otherwise the method :php:`render()` would not be found.
-   In the future, this should no longer be necessary.
+   Otherwise the method :php:`render()` would not be found. If you use the latest TYPO3 9 or higher, this should no longer be necessary.
 
 Every ViewHelper must inherit from the class
 :php:`\TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper`.


### PR DESCRIPTION
Without this information I could not write a ViewHelper class. It always ended up in an Exception:

    Uncaught TYPO3 Exception
    Method AFM\Registeraddress\ViewHelpers\GetCaptchaViewHelper::render() does not existReflectionException thrown in file
    /home/opaque/domains/mydomain/typo3_src-8.7.19/typo3/sysext/extbase/Classes/Reflection/ReflectionService.php in line 571.72 ReflectionMethod::__construct("AFM\Registeraddress\ViewHelpers\GetCaptchaViewHelper", "render")/home/opaque/domains/mydomain/typo3_src-8.7.19/typo3/sysext/extbase/Classes/Reflection/ReflectionService.php:00569:         $this->dataCacheNeedsUpdate = true;
    00570:         if (!isset($this->methodReflections[$className][$methodName])) {00571:             $this->methodReflections[$className][$methodName] = new MethodReflection($className, $methodName);00572:         }
    00573:         return $this->methodReflections[$className][$methodName];ReflectionException thrown in file
    /home/opaque/domains/mydomain/typo3_src-8.7.19/typo3/sysext/extbase/Classes/Reflection/ReflectionService.php in line 571.72 ReflectionMethod::__construct("AFM\Registeraddress\ViewHelpers\GetCaptchaViewHelper", "render")/home/opaque/domains/mydomain/typo3_src-8.7.19/typo3/sysext/extbase/Classes/Reflection/ReflectionService.php:00569:         $this->dataCacheNeedsUpdate = true;
    00570:         if (!isset($this->methodReflections[$className][$methodName])) {00571:             $this->methodReflections[$className][$methodName] = new MethodReflection($className, $methodName);00572:         }
    00573:         return $this->methodReflections[$className][$methodName];Method AFM\Registeraddress\ViewHelpers\GetCaptchaViewHelper::render() does not existReflectionException thrown in file
    /home/opaque/domains/mydomain/typo3_src-8.7.19/typo3/sysext/extbase/Classes/Reflection/ReflectionService.php in line 571.72 ReflectionMethod::__construct("AFM\Registeraddress\ViewHelpers\GetCaptchaViewHelper", "render")/home/opaque/domains/mydomain/typo3_src-8.7.19/typo3/sysext/extbase/Classes/Reflection/ReflectionService.php:00569:         $this->dataCacheNeedsUpdate = true;
    00570:         if (!isset($this->methodReflections[$className][$methodName])) {00571:             $this->methodReflections[$className][$methodName] = new MethodReflection($className, $methodName);00572:         }
    00573:         return $this->methodReflections[$className][$methodName];Method AFM\Registeraddress\ViewHelpers\GetCaptchaViewHelper::render() does not existReflectionException thrown in file
    /home/opaque/domains/mydomain/typo3_src-8.7.19/typo3/sysext/extbase/Classes/Reflection/ReflectionService.php in line 571.72 ReflectionMethod::__construct("AFM\Registeraddress\ViewHelpers\GetCaptchaViewHelper", "render")/home/opaque/domains/mydomain/typo3_src-8.7.19/typo3/sysext/extbase/Classes/Reflection/ReflectionService.php:00569:         $this->dataCacheNeedsUpdate = true;
    00570:         if (!isset($this->methodReflections[$className][$methodName])) {00571:             $this->methodReflections[$className][$methodName] = new MethodReflection($className, $methodName);00572:         }
    00573:         return $this->methodReflections[$className][$methodName];