### PR TITLE
[FIX] Remove false note about requireCHashArgumentForActionArguments

### DIFF
--- a/Documentation/b-ExtbaseReference/Index.rst
+++ b/Documentation/b-ExtbaseReference/Index.rst
@@ -209,8 +209,6 @@ Activate features for Extbase or a specific plugin.
     Default is `false`.
 
 `features.requireCHashArgumentForActionArguments`
-    Only available below `config.tx_extbase`, not for individual plugins!
-
     Do not force a cHash for arguments used in actions. If this is turned on, all requests with
     arguments but no, or an invalid cHash, are handled as `pageNotFoundOnCHashError`.
     Default is `true`.


### PR DESCRIPTION
As it states in [Changelog/8.5/Breaking-78002](https://docs.typo3.org/typo3cms/extensions/core/latest/Changelog/8.5/Breaking-78002-EnforceCHashArgumentForExtbaseActions.html), `requireCHashArgumentForActionArguments` can be used per plugin