### PR TITLE
Repository replace() got removed since TYPO3 7.x

### DIFF
--- a/Documentation/6-Persistence/2-configure-the-backends-inputforms.rst
+++ b/Documentation/6-Persistence/2-configure-the-backends-inputforms.rst
@@ -763,15 +763,6 @@ The opponent of :php:`add()`. An object will be removed from the Repository and 
 gonna be deleted from the database after finishing the Extension's loop. The
 method :php:`removeAll()` empties the whole Repository.
 
-
-:php:`replace($existingObject, $newObject)`
--------------------------------------------
-
-Replaces an existing object with a new object. Instead of the combination of
-`add()` and `remove()` this method keeps the existing object in the
-database.
-
-
 :php:`update($modifiedObject)`
 ------------------------------
 


### PR DESCRIPTION
\TYPO3\CMS\Extbase\Persistence\Repository replace-function got removed since update to TYPO3 7.x. it doesn't exist in 8.7 anymore. see:
https://api.typo3.org/typo3cms/8/html/class_t_y_p_o3_1_1_c_m_s_1_1_extbase_1_1_persistence_1_1_repository.html#a4872b38b18e2db4036b0c95708990ee6