### PR TITLE
Extending from AbstractValidator

### DIFF
--- a/Documentation/9-CrosscuttingConcerns/2-validating-domain-objects.rst
+++ b/Documentation/9-CrosscuttingConcerns/2-validating-domain-objects.rst
@@ -261,7 +261,7 @@ blog post is always build-on the scheme *Maintopic: Title*:
 
    class TitleValidator extends AbstractValidator
    {
-      public function validate($value)
+      protected function isValid($value)
       {
          // $value is the title string
          if (count(explode(':', $value)) >= 2) {


### PR DESCRIPTION
When extending an AbstractValidator isValid($value) has to be implemented as it is abstract. validate($value) automatically calls isValid($value)
See: https://api.typo3.org/typo3cms/current/html/class_t_y_p_o3_1_1_c_m_s_1_1_extbase_1_1_validation_1_1_validator_1_1_abstract_validator.html#a72063d2e922edda5321b1970297eb0c3