### PR TITLE
Fix queryBuilder code example

### DIFF
--- a/Documentation/6-Persistence/3-implement-individual-database-queries.rst
+++ b/Documentation/6-Persistence/3-implement-individual-database-queries.rst
@@ -401,7 +401,7 @@ is translated by Extbase to the following query:
            ->from('tx_sjroffers_domain_model_offer')
            ->where(...)
 
-       $rows = $query->execute->fetchRows();
+       $rows = $query->execute()->fetchAll();
 
     You have to handle the creation and maintenance of the objects by yourself.
 


### PR DESCRIPTION
'execute' is a function and there is no fetchRows() in Doctrine\DBAL\Driver\Mysqli\MysqliStatement
https://www.doctrine-project.org/api/dbal/2.8/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.html