### PR TITLE
relevant method has changed in abstract class

### DIFF
--- a/Documentation/9-CrosscuttingConcerns/2-validating-domain-objects.rst
+++ b/Documentation/9-CrosscuttingConcerns/2-validating-domain-objects.rst
@@ -317,7 +317,7 @@ case::
 
     class UserValidator extends \TYPO3\CMS\Extbase\Validation\Validator\AbstractValidator
     {
-        public function validate($user)
+        public function isValid($user)
         {
             if (! $user instanceof \MyVendor\ExtbaseExample\Domain\Model\User) {
                 $this->addError('The given Object is not a User.', 1262341470);
@@ -346,7 +346,7 @@ passwords. This is made quickly::
 
     class UserValidator extends \TYPO3\CMS\Extbase\Validation\Validator\AbstractValidator
     {
-        public function validate($user)
+        public function isValid($user)
         {
             if (! $user instanceof \MyVendor\ExtbaseExample\Domain\Model\User) {
                 $this->addError('The given Object is not a User.', 1262341470);


### PR DESCRIPTION
at least  in version 8.7.24 you should not redefine the validate() but the isValid() method. 
Otherwise your validation will not work: 
* you miss $this->result so $this->result->addError() will fail in $this->addError()
* validate() returns wrong type