### PR TITLE
Remove trailing slash

### DIFF
--- a/Documentation/4-FirstExtension/7-configuring-the-plugin.rst
+++ b/Documentation/4-FirstExtension/7-configuring-the-plugin.rst
@@ -27,7 +27,7 @@ create in the top level of our extension directory.
         // non-cacheable actions
         [
             'StoreInventory' => '',
-        ],
+        ]
     );
 
 With the first line we ensure, that the PHP code can not be


### PR DESCRIPTION
Trailing slash for function parameters raise a parse error. 
https://wiki.php.net/rfc/revisit-trailing-comma-function-args