### PR TITLE
Fix typo in 5-controlling-the-flow.rst

### DIFF
--- a/Documentation/4-FirstExtension/5-controlling-the-flow.rst
+++ b/Documentation/4-FirstExtension/5-controlling-the-flow.rst
@@ -93,5 +93,5 @@ told to return the passed content back to TYPO3, rendered based on an HTML templ
 
     return $this->view->render();
 
-This line is declined by Extbase for us, if we not initiate the rendering process ourselves.
+This line is defined by Extbase for us, if we not initiate the rendering process ourselves.
 So we can omit the line in our case.


### PR DESCRIPTION
I believe it is a typo in the documentation ([https://docs.typo3.org/m/typo3/book-extbasefluid/master/en-us/4-FirstExtension/5-controlling-the-flow.html]), and I think the author meant "defined" (instead of "declined").