### PR TITLE
Use extension key for configurePlugin and registerPlugin

### DIFF
--- a/Documentation/4-FirstExtension/7-configuring-the-plugin.rst
+++ b/Documentation/4-FirstExtension/7-configuring-the-plugin.rst
@@ -13,13 +13,14 @@ In our example there is only one controller action combination, namely ``StoreIn
 This combination is registered in the file :file:`ext_localconf.php`, that we
 create in the top level of our extension directory.
 
+
 .. code-block:: php
 
     <?php
     defined('TYPO3_MODE') || die('Access denied.');
 
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-        'MyVendor.StoreInventory',
+        'store_inventory',
         'Pi1',
         [
             'StoreInventory' => 'list',
@@ -33,9 +34,9 @@ create in the top level of our extension directory.
 With the first line we ensure, that the PHP code can not be
 called directly outside of TYPO3, for security reasons.  The static method
 :php:`\TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin()`
-offers several arguments.  With the first one we assign the extension key (it
-derives from the name of the extension directory), prefixed by the vendor
-namespace, followed by a dot. This indicates, that we use namespaces for our php
+offers several arguments.
+With the first one we assign the extension key (it derives from the name of the extension directory).
+This indicates, that we use namespaces for our php
 classes.  With the second argument we give a unique name for the plugin (in
 UpperCamelCase notation).  Because of historical reasons there is often used
 ``Pi1``, but maybe it is better to use more meaningful names like
@@ -67,7 +68,7 @@ of the content element *Plugin*. For this we insert the following line into a ne
     <?php
 
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-        'MyVendor.StoreInventory',
+        'store_inventory',
         'Pi1',
         'The Store Inventory List',
         'EXT:store_inventory/Resources/Public/Icons/Extension.svg'

--- a/Documentation/7-Controllers/2-Configuring-and-embedding-Frontend-Plugins.rst
+++ b/Documentation/7-Controllers/2-Configuring-and-embedding-Frontend-Plugins.rst
@@ -12,17 +12,17 @@ be configured. Both steps are resolved by two Extbase API-methods. These calls
 are located in two different files.
 
 In the file :file:`EXT:sjr_offers/ext_tables.php` you have to register every plugin as
-a content element with TYPO3 using the static method registerPlugin().
+a content element with TYPO3 using the static method :php:`registerPlugin()`.
 
 .. code-block:: php
 
    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-        'VendorName.'.$_EXTKEY,
+        'extension_key',
         'List',
         'The Inventory List'
    );
 
-The method `registerPlugin()` expects three arguments. The first argument is the
+The method :php:`registerPlugin()` expects three arguments. The first argument is the
 extension key (sjr_offers in our example). This key is the same as the directory
 name of the extension.
 The second parameter is a freely selectable name of the plugin (a short,
@@ -37,13 +37,11 @@ For the second step we have to configure the behaviour of the plugin in the file
 :file:`EXT:sjr_offers/ext_localconf.php`  with the static method `configurePlugin()`.
 Beside the actions that have to be called on by the plugin, you also have to
 specify which content will be stored in cache.
-.. code-block:: php
-
 
 .. code-block:: php
 
    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-        'VendorName.'.$_EXTKEY,
+        'example_extension',
         'List',
         ['Inventory' => 'list']
    );

--- a/Documentation/b-ExtbaseReference/Index.rst
+++ b/Documentation/b-ExtbaseReference/Index.rst
@@ -53,7 +53,7 @@ backend. Let's have a look at the following two files:
 
     $pluginName = 'ExamplePlugin';
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-        'Vendor.ExtensionName',
+        'extension_key',
         $pluginName,
         $controllerActionCombinations,
         $uncachedActions
@@ -75,7 +75,7 @@ same format as above, containing all the non-cached-actions.
 .. code-block:: php
 
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-        'Vendor.ExtensionName',
+        'extension_key',
         'ExamplePlugin',
         'Title used in Backend'
     );
@@ -91,7 +91,7 @@ frontend plugin within the files :file:`ext_localconf.php` and :file:`Configurat
 .. code-block:: php
 
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-        'Vendor.ExampleExtension',
+        'example_extension',
         'Blog',
         [
             'Blog' => 'index,show,new,create,delete,deleteAll,edit,update,populate',
@@ -110,7 +110,7 @@ frontend plugin within the files :file:`ext_localconf.php` and :file:`Configurat
 .. code-block:: php
 
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-        'Vendor.ExampleExtension',
+        'example_extension',
         'Blog',
         'A Blog Example',
         'EXT:blog/Resources/Public/Icons/Extension.svg'


### PR DESCRIPTION
See Changelog:
https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.1/Deprecation-88995-CallingRegisterPluginWithVendorName.html