### PR TITLE
Add note to point out deprecation of Extbase Command Controllers (9.5)

### DIFF
--- a/Documentation/10-Outlook/3-Command-controllers.rst
+++ b/Documentation/10-Outlook/3-Command-controllers.rst
@@ -6,6 +6,14 @@
 Command Controllers
 ===================
 
+.. note::
+
+   Since TYPO3 8, it is possible to use Symfony commands in TYPO3. This is the preferred method
+   and is documented in "TYPO3 Explained" :ref:`t3coreapi:cli-mode-command-controllers`.
+   You can still use Extbase Command Controllers, but they have been
+   `deprecated in 9.4 <https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.4/Deprecation-85977-ExtbaseCommandControllersAndCliAnnotation.html>`__
+   and will trigger a PHP :php:`E_USER_DEPRECATED` error if used from the command line.
+
 Command controllers make functionality available at the command line and in the scheduler backend module.
 
 They can provide functionality for recurring tasks like mail queues, cleanups, imports and


### PR DESCRIPTION
Related: https://github.com/TYPO3-Documentation/T3DocTeam/issues/112
Releases: 9.5, 8.7