### PR TITLE
Update 1-prepare-the-database.rst

### DIFF
--- a/Documentation/6-Persistence/1-prepare-the-database.rst
+++ b/Documentation/6-Persistence/1-prepare-the-database.rst
@@ -52,7 +52,7 @@ aggregate the objects of the class
       sys_language_uid int(11) DEFAULT 0 NOT NULL,
       l18n_parent int(11) DEFAULT 0 NOT NULL,
       l18n_diffsource mediumblob NOT NULL,
-      access_group int(11) DEFAULT 0 NOT NULL,
+      fe_group int(11) DEFAULT 0 NOT NULL,
 
       PRIMARY KEY (uid),
       KEY parent (pid),


### PR DESCRIPTION
access_group is used with pages-records only and has a different meaning,
fe_group is mentioned in the list of fields.