### PR TITLE
Change "Chapter x" into right links

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -6,7 +6,7 @@ Developing TYPO3 Extensions with Extbase and Fluid
 ==================================================
 
 :Version:
-      10.0 (development)
+      |release|
 
 :Language:
       en

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -20,7 +20,7 @@
 
 project     = Developing TYPO3 Extensions with Extbase and Fluid
 #version     = master
-release     = 10.0 (development)
+release     = 11.0 (development)
 t3author    = TYPO3 community
 copyright   = Copyright since 2009
 

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,6 @@
     "type": "typo3-cms-documentation",
     "description": "Developing TYPO3 Extensions with Extbase and Fluid",
     "require": {
-      "typo3/cms-core": "^10.0"
+      "typo3/cms-core": "^11.0"
     }
 }


### PR DESCRIPTION
**Description:**

While reading the Documentation of Developing TYPO3 Extensions with Extbase and Fluid
 https://docs.typo3.org/m/typo3/book-extbasefluid/master/en-us/Index.html
I come across clues that pointed out to Chapter 9, 10...
I couldnt find those Chapters or something msrked as Chapter 9. It is unclear where to look for.

**ToDo:**

- Chage "Chapter x" into right links

![image](https://user-images.githubusercontent.com/17493539/84624554-e8831200-aee1-11ea-9cb4-8557a4d85eef.png)
![image](https://user-images.githubusercontent.com/17493539/84624627-094b6780-aee2-11ea-8270-a8495ff787c4.png)

