### PR TITLE
correct additional header

### DIFF
--- a/Documentation/8-Fluid/2-using-different-output-formats.rst
+++ b/Documentation/8-Fluid/2-using-different-output-formats.rst
@@ -57,7 +57,7 @@ You can use the following TypoScript::
 
       config {
          disableAllHeaderCode = 1
-         additionalHeaders = Content-type:application/xml
+         additionalHeaders.10.header = Content-type:application/xml
          xhtml_cleaning = 0
          admPanel = 0
       }


### PR DESCRIPTION
additionalHeaders are defined as an array of header configurations. See https://docs.typo3.org/m/typo3/reference-typoscript/master/en-us/Setup/Config/Index.html#additionalheaders 

Therefore the example doesnt work as before. Can be merged to LTS 10 and 9