### PR TITLE
cli_dispatch.phpsh was removed with LTS 9

### DIFF
--- a/Documentation/10-Outlook/3-Command-controllers.rst
+++ b/Documentation/10-Outlook/3-Command-controllers.rst
@@ -120,7 +120,8 @@ simple:arguments`. The result will be something like:
       example:simple:arguments
 
     USAGE:
-      /typo3/cli_dispatch.phpsh typo3/cli_dispatch.phpsh extbase simple:arguments [<options>] <required>
+      /typo3/sysext/core/bin/typo3h extbase simple:arguments [<options>] <required>
+      /vendor/bin/typo3 extbase simple:arguments [<options>] <required> (composer)
 
     ARGUMENTS:
       --required
@@ -162,7 +163,8 @@ simple:arguments`:
       example:simple:arguments
 
     USAGE:
-      /typo3/cli_dispatch.phpsh typo3/cli_dispatch.phpsh extbase simple:arguments [<options>] <required>
+      /typo3/sysext/core/bin/typo3 extbase simple:arguments [<options>] <required> (non-composer)
+      /vendor/bin/typo3 extbase simple:arguments [<options>] <required> (composer)
 
     ARGUMENTS:
       --required           This is an required argument.


### PR DESCRIPTION
https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/8.7/Deprecation-80468-CommandLineInterfaceCliKeysAndCli_dispatchphpsh.html