### PR TITLE
Remove vendorName from ExtensionUtility::[registerModule|configurePlu…

### DIFF
--- a/Documentation/4-FirstExtension/7-configuring-the-plugin.rst
+++ b/Documentation/4-FirstExtension/7-configuring-the-plugin.rst
@@ -20,7 +20,7 @@ our extension directory.
     defined('TYPO3_MODE') || die('Access denied.');
 
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-        'MyVendor.StoreInventory',
+        'StoreInventory',
         'InventoryList',
         [
             \Vendor\StoreInventory\Controller\StoreInventoryController::class => 'list',
@@ -35,14 +35,15 @@ With the first line we prevent calling the PHP code in this file without TYPO3 c
 (this is basically a small security measure).
 The static method :php:`\TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin()`
 is used to configure the plugin for use in TYPO3.
-The first parameter denotes the extension key and vendor name (MyVendor.ExtensionKey).
-With the second argument we give an unique name for the plugin (in UpperCamelCase notation).
+The first parameter denotes the extension key in UpperCamelCase (ExtensionKey).
+With the second argument we give an unique name for the plugin (also in UpperCamelCase notation).
 This is later used to clearly identify the plugin.
 The third argument is an array with all allowed controller action combinations.
-The array key is the controller name (without the suffix ``Controller``)
+The array key is the fully-qualified controller class name
 and the array value is a comma separated list of all allowed actions.
 In our case this is the ``list`` action (also without the suffix ``Action``).
-Thus the array :php:`['Inventory' -> 'list']` allows to execute the method :php:`listAction()`
+Thus the array :php:`[\Vendor\StoreInventory\Controller\StoreInventoryController::class -> 'list']`
+allows to execute the method :php:`listAction()`
 in the :php:`\MyVendor\StoreInventory\Controller\StoreInventoryController`.
 All actions are cached by default. If you need to have an uncached action,
 specify the controller/action combination as fourth parameter.
@@ -58,15 +59,15 @@ To achieve this insert the following line into a new file :file:`Configuration/T
     <?php
 
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-        'MyVendor.StoreInventory',
+        'StoreInventory',
         'InventoryList',
         'The Store Inventory List',
         'EXT:store_inventory/Resources/Public/Icons/Extension.svg'
     );
 
 
-The first argument is like the method :php:`configurePlugin()` again the vendor namespace
-and extension key and the second is the name of the plugin.
+The first argument is like the method :php:`configurePlugin()` again the
+extension key and the second is the name of the plugin.
 The third argument is the title of the plugin used in the select box of the content element.
 After installing the extension (and clearing the cache) we can insert the plugin on a page.
 Don't forget to set the sys_folder, where the products are stored as the starting point

--- a/Documentation/7-Controllers/2-Configuring-and-embedding-Frontend-Plugins.rst
+++ b/Documentation/7-Controllers/2-Configuring-and-embedding-Frontend-Plugins.rst
@@ -1,7 +1,7 @@
 .. include:: ../Includes.txt
 
 Configuring and embedding Frontend Plugins
-================================================================================================
+==========================================
 
 The action should be called on by a frontend-plugin. We've already addressed the
 configuration of a simple frontend-plugin in chapter 4 in the section
@@ -19,13 +19,13 @@ a content element with TYPO3 using the static method :php:`registerPlugin()`.
 .. code-block:: php
 
    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-        'extension_key',
+        'ExtensionKey',
         'List',
         'The Inventory List'
    );
 
 The method :php:`registerPlugin()` expects three arguments. The first argument is the
-extension key (`extension_key` in our example). This key is the same as the directory
+extension key in UpperCamelCase notation (`ExtensionKey` in our example). This key is the same as the directory
 name of the extension.
 The second parameter is a freely selectable name of the plugin (a short,
 meaningful name in UpperCamelCase). The plugin name plays a significant role in
@@ -43,14 +43,14 @@ specify which content will be stored in cache.
 .. code-block:: php
 
    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-       'example_extension',
+       'ExampleExtension',
        'List',
        [\Vendor\ExampleExtension\Controller\InventoryController::class => 'list,detail'],
        [\Vendor\ExampleExtension\Controller\InventoryController::class => 'detail']
    );
 
 The method expects 4 arguments. The first argument is, just like the one used in
-the registration process, the extension key. With the second argument, the
+the registration process, the extension key in UpperCamelCase notation. With the second argument, the
 plugin name, Extbase can assign the configuration to the appropriate plugin.
 
 The third argument is an array which contains all controller-action combinations

--- a/Documentation/b-ExtbaseReference/Index.rst
+++ b/Documentation/b-ExtbaseReference/Index.rst
@@ -46,15 +46,15 @@ backend. Let's have a look at the following two files:
 
     $pluginName = 'ExamplePlugin';
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-        'extension_key',
+        'ExtensionKey',
         $pluginName,
         $controllerActionCombinations,
         $uncachedActions
     );
 
-In addition to the extension key and a unique name of the plugin (line 2 and 3),
+In addition to the extension key and a unique name of the plugin (line 3 and 4),
 the allowed combinations of the controller and actions are determined.
-`$controllerActionCombinations` is an associative array. The Keys of this array
+`$controllerActionCombinations` is an associative array. The keys of this array
 are the allowed controller classes, and the values are a comma-separated list of
 allowed actions per controller. The first action of the first controller is the
 default action.
@@ -68,7 +68,7 @@ same format as above, containing all the non-cached-actions.
 .. code-block:: php
 
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-        'extension_key',
+        'ExtensionKey',
         'ExamplePlugin',
         'Title used in Backend'
     );
@@ -84,7 +84,7 @@ frontend plugin within the files :file:`ext_localconf.php` and :file:`Configurat
 .. code-block:: php
 
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-        'example_extension',
+        'ExampleExtension',
         'Blog',
         [
             \Vendor\ExampleExtension\Controller\BlogController::class => 'index,show,new,create,delete,deleteAll,edit,update,populate',
@@ -103,7 +103,7 @@ frontend plugin within the files :file:`ext_localconf.php` and :file:`Configurat
 .. code-block:: php
 
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-        'example_extension',
+        'ExampleExtension',
         'Blog',
         'A Blog Example',
         'EXT:blog/Resources/Public/Icons/Extension.svg'


### PR DESCRIPTION
…gin]

See: https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/master/Breaking-92609-UseControllerClassesWhenRegisteringPluginsmodules.html

Related: https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/1082