### PR TITLE
[TASK] Remove $actionMethodName property from API

### DIFF
--- a/Documentation/b-ExtbaseReference/Index.rst
+++ b/Documentation/b-ExtbaseReference/Index.rst
@@ -398,9 +398,6 @@ ActionController API
 The action controller is usually the base class for your own controller. Below
 you see the most important properties of the action controller:
 
-`$actionMethodName`
-    Name of the executed action.
-
 `$argumentMappingResults`
     Results of the argument mapping. Is used especially in the errorAction.
 


### PR DESCRIPTION
See Core Important 92996
See https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/1082
