### PR TITLE
change $_EXTKEY to extension string

### DIFF
--- a/Documentation/4-FirstExtension/2-create-folder-structure-and-configuration-files.rst
+++ b/Documentation/4-FirstExtension/2-create-folder-structure-and-configuration-files.rst
@@ -60,7 +60,7 @@ of the *Core Api Reference* manual.
 
    <?php
 
-   $EM_CONF[$_EXTKEY] = [
+   $EM_CONF['store_inventory'] = [
        'title' => 'Store Inventory',
        'description' => 'An extension to manage a stock.',
        'category' => 'plugin',


### PR DESCRIPTION
cause $_EXTKEY is obsolete: https://wiki.typo3.org/Exception/CMS/1365429656