### PR TITLE
add renderType definition to TCA language fields

### DIFF
--- a/Documentation/9-CrosscuttingConcerns/1-localizing-and-internationalizing-an-extension.rst
+++ b/Documentation/9-CrosscuttingConcerns/1-localizing-and-internationalizing-an-extension.rst
@@ -350,6 +350,7 @@ translation relates to.
                'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.php:LGL.language',
                'config' => [
                    'type' => 'select',
+                   'renderType' => 'selectSingle',
                    'foreign_table' => 'sys_language',
                    'foreign_table_where' => 'ORDER BY sys_language.title',
                    'items' => [
@@ -364,6 +365,7 @@ translation relates to.
                'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.php:LGL.l18n_parent',
                'config' => [
                  'type' => 'select',
+                 'renderType' => 'selectSingle',
                  'items' => [
                      ['', 0],
                  ],


### PR DESCRIPTION
It seems, that TCA type select need a renderType definition. 
Otherwise you got "Unknown type: select, render type: select" in Backend View in TYPO3 10.4.12