### PR TITLE
change naming off TCA field for language parameter

### DIFF
--- a/Documentation/9-CrosscuttingConcerns/1-localizing-and-internationalizing-an-extension.rst
+++ b/Documentation/9-CrosscuttingConcerns/1-localizing-and-internationalizing-an-extension.rst
@@ -358,7 +358,7 @@ translation relates to.
                    ],
                ],
            ],
-           'l18n_parent' => [
+           'l10n_parent' => [
                'displayCond' => 'FIELD:sys_language_uid:>:0',
                'exclude' => 1,
                'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.php:LGL.l18n_parent',
@@ -373,7 +373,7 @@ translation relates to.
                        sys_language_uid IN (-1,0)',
                ],
            ],
-           'l18n_diffsource' => [
+           'l10n_diffsource' => [
                'config' => [
                  'type' =>'passthrough'
                ],


### PR DESCRIPTION
In the paragraph before code example fields "l10n_parent" "l10n_diffsource" are dicribed.
But in code example "l18n_parent" and "l18n_diffsource" is used. But this fields only used for tt_content table. 
Changed naming of TCA fields to "l10n_parent" and "l10n_diffsource".