### PR TITLE
Delete spaces in TCA example

### DIFF
--- a/Documentation/9-CrosscuttingConcerns/1-localizing-and-internationalizing-an-extension.rst
+++ b/Documentation/9-CrosscuttingConcerns/1-localizing-and-internationalizing-an-extension.rst
@@ -368,9 +368,7 @@ translation relates to.
                      ['', 0],
                  ],
                  'foreign_table' => 'tx_blogexample_domain_model_blog',
-                 'foreign_table_where' => 'AND tx_blogexample_domain_model_blog.uid=###REC_FIELD_
-                       l18n_parent### AND tx_blogexample_domain_model_blog.
-                       sys_language_uid IN (-1,0)',
+                 'foreign_table_where' => 'AND tx_blogexample_domain_model_blog.uid=###REC_FIELD_l18n_parent### AND tx_blogexample_domain_model_blog.         sys_language_uid IN (-1,0)',
                ],
            ],
            'l18n_diffsource' => [


### PR DESCRIPTION
If you copy the code, the code is added in more than one line. 
This could lead to errors and confusion if there is no error output. Especially for beginners