### PR TITLE
change naming off TCA field for language parameter

### DIFF
--- a/Documentation/9-CrosscuttingConcerns/1-localizing-and-internationalizing-an-extension.rst
+++ b/Documentation/9-CrosscuttingConcerns/1-localizing-and-internationalizing-an-extension.rst
@@ -341,7 +341,7 @@ translation relates to.
    return [
        // ...
        'types' => [
-           '1' => ['showitem' => 'l18n_parent , sys_language_uid, hidden, title,
+           '1' => ['showitem' => 'l10n_parent , sys_language_uid, hidden, title,
                        description, logo, posts, administrator'],
        ],
        'columns' => [
@@ -350,7 +350,6 @@ translation relates to.
                'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.php:LGL.language',
                'config' => [
                    'type' => 'select',
-                   'renderType' => 'selectSingle',
                    'foreign_table' => 'sys_language',
                    'foreign_table_where' => 'ORDER BY sys_language.title',
                    'items' => [
@@ -359,21 +358,22 @@ translation relates to.
                    ],
                ],
            ],
-           'l18n_parent' => [
+           'l10n_parent' => [
                'displayCond' => 'FIELD:sys_language_uid:>:0',
                'exclude' => 1,
-               'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.php:LGL.l18n_parent',
+               'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.php:LGL.l10n_parent',
                'config' => [
                  'type' => 'select',
-                 'renderType' => 'selectSingle',
                  'items' => [
                      ['', 0],
                  ],
                  'foreign_table' => 'tx_blogexample_domain_model_blog',
-                 'foreign_table_where' => 'AND tx_blogexample_domain_model_blog.uid=###REC_FIELD_l18n_parent### AND tx_blogexample_domain_model_blog.         sys_language_uid IN (-1,0)',
+                 'foreign_table_where' => 'AND tx_blogexample_domain_model_blog.uid=###REC_FIELD_
+                       l10n_parent### AND tx_blogexample_domain_model_blog.
+                       sys_language_uid IN (-1,0)',
                ],
            ],
-           'l18n_diffsource' => [
+           'l10n_diffsource' => [
                'config' => [
                  'type' =>'passthrough'
                ],


### PR DESCRIPTION
In paragraph before TCA code example fields "l10n_parent" "l10n_diffsource" are dicribed.
But in code example "l18n_parent" and "l18n_diffsource" is used. But this fields only used for tt_content table.
Changed naming of TCA fields to "l10n_parent" and "l10n_diffsource".