### PR TITLE
Migrate Wiki content: Default_Orderings_and_Query_Settings_in_Repository

### DIFF
--- a/Documentation/6-Persistence/2a-creating-the-repositories.rst
+++ b/Documentation/6-Persistence/2a-creating-the-repositories.rst
@@ -138,12 +138,53 @@ on which pages on TYPO3's page tree (see below for TYPO3's concept of the page
 tree) it should seek and file the objects. Without any further definitions
 Extbase will use the page tree's root (the globe).
 
+
+Accessible variables in the class :php:`Repository`
+===================================================
+
+.. _extbase_repository_default_orderings:
+
+Default orderings
+-----------------
+
+.. todo: should we mention the method setDefaultOrderings?
+
+An alternative default ordering can be stored in the protected variable
+:php:`$defaultOrderings` of classes extending the class :php:`Repository`.
+the default orderings are being applied when there is no ordering defined in
+the query (see :ref:`extbase_query_orderings`)
+
+In the following example the records get ordered by field :sql:`sorting`::
+
+   use TYPO3\CMS\Extbase\Persistence\Repository;
+   use TYPO3\CMS\Extbase\Persistence\QueryInterface;
+
+   class FooRepository extends Repository {
+
+       // Order by BE sorting
+       protected $defaultOrderings = array(
+           'sorting' => QueryInterface::ORDER_ASCENDING
+       );
+
+   }
+
+Fields can be ordered reversely by setting the value of the array entry
+to :php:`QueryInterface::ORDER_DESCENDING`.
+
+
+.. todo Add information about the variable $defaultQuerySettings here
+
+.. _procedure_to_fetch_objects:
+
+Fetch Extbase objects
+=====================
+
 Generally, there are three cases which need to be distinguished: Persisting a
 newly created object, reaccessing an existing object and updating the properties
 of an existing object. When creating a new object, Extbase determines the
 destination pages in the following rule hierarchy:
 
-.. _procedure_to_fetch_objects:
+
 
 .. todo Check if the work for "Ausgangspunkt" is used as in Ch. 4
 

--- a/Documentation/6-Persistence/2a-creating-the-repositories.rst
+++ b/Documentation/6-Persistence/2a-creating-the-repositories.rst
@@ -138,10 +138,6 @@ on which pages on TYPO3's page tree (see below for TYPO3's concept of the page
 tree) it should seek and file the objects. Without any further definitions
 Extbase will use the page tree's root (the globe).
 
-
-Accessible variables in the class :php:`Repository`
-===================================================
-
 .. _extbase_repository_default_orderings:
 
 Default orderings
@@ -152,7 +148,8 @@ Default orderings
 An alternative default ordering can be stored in the protected variable
 :php:`$defaultOrderings` of classes extending the class :php:`Repository`.
 the default orderings are being applied when there is no ordering defined in
-the query (see :ref:`extbase_query_orderings`)
+the query (see :ref:`extbase_query_orderings`). The default orderings can be
+changed at running time by calling the function :php:`setDefaultOrderings()`.
 
 In the following example the records get ordered by field :sql:`sorting`::
 
@@ -172,7 +169,50 @@ Fields can be ordered reversely by setting the value of the array entry
 to :php:`QueryInterface::ORDER_DESCENDING`.
 
 
-.. todo Add information about the variable $defaultQuerySettings here
+.. _extbase_repository_default_query_settings:
+
+Default query settings
+----------------------
+
+The default query settings of a repository are stored in the protected variable
+:php:`$defaultQuerySettings` as an object of type
+:php:`QuerySettingsInterface`. This variable is usually called by setting
+it via the public function :php:`setDefaultQuerySettings()` from the function
+:php:`initializeObject()`.
+
+Here is an example::
+
+   use TYPO3\CMS\Extbase\Persistence\Repository;
+   use TYPO3\CMS\Extbase\Persistence\Generic\Typo3QuerySettings;
+
+   class ExampleRepository extends Repository {
+
+      // Example for repository wide settings
+      public function initializeObject() {
+         /** @var Typo3QuerySettings $querySettings */
+         $querySettings = new Typo3QuerySettings();
+
+         // don't add the pid constraint
+         $querySettings->setRespectStoragePage(false);
+         // set the storagePids to respect
+         $querySettings->setStoragePageIds(array(1, 26, 989));
+
+         // define the enablecolumn fields to be ignored, true ignores all of them
+         $querySettings->setIgnoreEnableFields(TRUE);
+
+         // define single fields to be ignored
+         $querySettings->setEnableFieldsToBeIgnored(array('disabled','starttime'));
+
+         // add deleted rows to the result
+         $querySettings->setIncludeDeleted(TRUE);
+
+         // don't add sys_language_uid constraint
+         $querySettings->setRespectSysLanguage(FALSE);
+
+         $this->setDefaultQuerySettings($querySettings);
+      }
+   }
+
 
 .. _procedure_to_fetch_objects:
 

--- a/Documentation/6-Persistence/3-implement-individual-database-queries.rst
+++ b/Documentation/6-Persistence/3-implement-individual-database-queries.rst
@@ -312,6 +312,11 @@ age value. (Here, the minimum age is more recent in the past than the maximum ag
 The ``logicalAnd()`` constraint then joins the two ``logicalOr()`` constraints, making a single
 constraint, overall.
 
+.. _extbase_query_orderings:
+
+Orderings in the query
+======================
+
 You can sort the result of a query by assigning one or more rules ``$query->setOrderings($orderings);``
 to the ``Query`` object. These rules are collected in an associative array. Each array element has the
 property name on which the sort is based as its key, and the search order constant as its value.


### PR DESCRIPTION
Backport: 10.4, 9.5

https://wiki.typo3.org/Default_Orderings_and_Query_Settings_in_Repository

refs TYPO3-Documentation/T3DocTeam#154