### PR TITLE
Use registerPlugin in TCA Overrides

### DIFF
--- a/Documentation/7-Controllers/2-Configuring-and-embedding-Frontend-Plugins.rst
+++ b/Documentation/7-Controllers/2-Configuring-and-embedding-Frontend-Plugins.rst
@@ -15,7 +15,7 @@ The plugin must be registered as a content type (plugin), and its behavior must
 be configured. Two Extbase API-methods resolve both steps. These calls
 are located in two different files.
 
-In the file :file:`EXT:extension_key/ext_tables.php` you have to register every plugin as
+In the file :file:`EXT:extension_key/Configuration/TCA/Overrides/tt_content.php` you have to register every plugin as
 a content element with TYPO3 using the static method :php:`registerPlugin()`.
 
 .. this isn't text for the srj example - correct?


### PR DESCRIPTION
RegisterPlugin should be called in tt_content.php TCA-Overrides, not in ext_tables.php, based on the comment of registerPlugin of the ExtensionUtility and the fact, that it only changes the tt_content TCA in the end.

Releases: master, 10.4