### PR TITLE
Update documentation: remove deprecated configuration example

### DIFF
--- a/Documentation/6-Persistence/5-modeling-the-class-hierarchy.rst
+++ b/Documentation/6-Persistence/5-modeling-the-class-hierarchy.rst
@@ -83,48 +83,6 @@ The name of the field that contains the type can be chosen freely. In our case, 
    ],
    // …
 
-You have to tell Extbase for every concrete class in which table the
-data of the instances are stored and with which type they should be stored. This is done in :file:`Configuration/Extbase/Persistence/Classes.php`.
-
-::
-
-    <?php
-    declare(strict_types = 1);
-
-    config.tx_extbase.persistence.classes {
-        MyVendor\MyExtension\Domain\Model\Organization {
-            mapping {
-                tableName = tx_myextension_domain_model_party
-                recordType = MyVendor\MyExtension\Domain\Model\Organization
-            }
-            subclasses {
-                \MyVendor\MyExtension\Domain\Model\Company = MyVendor\MyExtension\Domain\Model\Company
-                \MyVendor\MyExtension\Domain\Model\ScientificInstitution = MyVendor\MyExtension\Domain\Model\ScientificInstitution
-            }
-        }
-        MyVendor\MyExtension\Domain\Model\Person {
-            mapping {
-                tableName = tx_myextension_domain_model_party
-                recordType = \MyVendor\MyExtension\Domain\Model\Person
-            }
-        }
-        MyVendor\MyExtension\Domain\Model\Company {
-            mapping {
-                tableName = tx_myextension_domain_model_party
-                recordType = \MyVendor\MyExtension\Domain\Model\Company
-                columns {
-                    crdate.mapOnProperty = customCreationDateField
-                }
-            }
-        }
-        MyVendor\MyExtension\Domain\Model\ScientificInstitution {
-            mapping {
-                tableName = tx_myextension_domain_model_party
-                recordType = \MyVendor\MyExtension\Domain\Model\ScientificInstitution
-            }
-        }
-    }
-
 .. versionchanged:: 10.4
 
    With TYPO3 v10 the relationship between classes and tables has been moved into the file


### PR DESCRIPTION
* remove hint for TYPO3 10
* remove duplicate explanation
* remove TypoScript code, as only the PHP code is used in TYPO3 11 (afaik)