### PR TITLE
[BUGFIX] fix list rendering on "Validating Domain Objects"

### DIFF
--- a/Documentation/9-CrosscuttingConcerns/2-validating-domain-objects.rst
+++ b/Documentation/9-CrosscuttingConcerns/2-validating-domain-objects.rst
@@ -414,8 +414,7 @@ for example:
 Now there are two possibilities how validators can be
 registered for domain objects: 
 
-*  directly in the model via
-``@TYPO3\CMS\Extbase\Annotation\Validate`` annotation for single properties
+*  directly in the model via ``@TYPO3\CMS\Extbase\Annotation\Validate`` annotation for single properties
 *  with an own validator class for complete domain objects.
 
 .. important::


### PR DESCRIPTION
This fixes rendering of the list "directly in the model via" on https://docs.typo3.org/m/typo3/book-extbasefluid/master/en-us/9-CrosscuttingConcerns/2-validating-domain-objects.html#domain-model-with-user-defined-validator-class (towards the end of the paragraph)