### PR TITLE
[Deprecation] #94115, #94351

### DIFF
--- a/Documentation/10-Outlook/6-dispatching.rst
+++ b/Documentation/10-Outlook/6-dispatching.rst
@@ -114,7 +114,7 @@ or an alternative action should be loaded instead of the entries from
          method canHandleRequest() did not receive the request to be handled. This
          has changed in version 11, making the request handlers a mere wrapper to
          dispatch the request via the dispatcher.
-         franzholz: This seems to be still true and important to know. Maybe it is not 
+         franzholz: This seems to be still true and important to know. Maybe it is not
          the RequestHandler but an object executed before which collects the configuration.
 
 .. note::
@@ -286,34 +286,41 @@ returning a `ForwardResponse`::
 Redirecting a request
 ---------------------
 
-Within an action the current request can be redirected to another action::
+Within an action the current request can be redirected to another action
+by returning the redirect method::
 
-   $this->redirect('newAction', 'ForeignController', 'ForeignExtension', ['param1' => $param1, 'param2' => $param2]);
-   
+   return $this->redirect(
+      'newAction',
+      'ForeignController',
+      'ForeignExtension',
+      ['param1' => $param1, 'param2' => $param2]
+   );
+
 or to another uri::
-   
-   $this->redirectToUri('https://example.com');
+
+   return $this->redirectToUri('https://example.com');
 
 .. note::
 
-   A redirection leads to a reload of the page. All the $_REQUEST variable is lost. Therefore all data needed on the 
-   destination must be passed as an array in parameter 4. 
-   If the redirection happens after a new / create form, then it must be taken care that the database record is stored
+   A redirection leads to a reload of the page. All the $_REQUEST variable is
+   lost. Therefore all data needed on the
+   destination must be passed as an array in parameter 4.
+   If the redirection happens after a new / create form, then it must be taken
+   care that the database record is stored
    into the database before the redirection::
-   
+
       // use \TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager
       $persistenceManager->persistAll();
-   
+
    `Data Transfer Objects in Extbase <https://usetypo3.com/dtos-in-extbase.html>`__ are an alternative solution
-   to store the form data beween redirections.
+   to store the form data between redirections.
 
 .. todo: Replace the ObjectManager class. deprecation #90803 in TYPO3 11.2.
 
 In the first example, Extbase will build the URL and call :php:`redirectToUri()`.
 
-Extbase will adjust the response to contain the redirect and stop execution by
-throwing an exception.
-
-.. todo: This is not true anymore and needs to be rewritten. Unfortunately there is
-         no alternative to `redirect` and `redirectToUri` yet, but it will change
-         very soon (in version 10.1.).
+.. versionchanged:: 11.3
+   Formerly the methods :php:`redirect` and :php:`redirectToUri` depended on
+   throwing a :php:`StopActionException`. This Exception has however been
+   deprecated with 11.3 as it is not PSR-7 conform. Therefore returning the
+   results of the redirect methods becomes mandatory with TYPO3 12.

--- a/Documentation/3-BlogExample/11-Alternative-route-creating-a-new-posting.rst
+++ b/Documentation/3-BlogExample/11-Alternative-route-creating-a-new-posting.rst
@@ -77,7 +77,7 @@ Lets take a look at the called method ``newAction()``:
       *
       * @param Blog $blog The blog the post belogs to
       * @param Post $newPost A fresh post object taken as a basis for the rendering
-      * @return void
+      * @return ResponseInterface
       * @Extbase\IgnoreValidation("newPost")
       */
       public function newAction(Blog $blog, Post $newPost = null): ResponseInterface
@@ -114,20 +114,32 @@ it checks, if the parameter is valid. The target for the parameter ``$blog`` is 
 class :php:`\FriendsOfTYPO3\BlogExample\Domain\Model\Blog`, for the parameter
 ``$newPost`` it is an instance of the class
 :php:`\FriendsOfTYPO3\BlogExample\Domain\Model\Post`.
-A source parameter with value 12 for the :php:`convert` method of the PropertyMapper will make a conversion into the blog object for record with :php:`$blog->uid == 12`.
+A source parameter with value 12 for the :php:`convert` method of
+the PropertyMapper will make a conversion into the blog object for
+record with :php:`$blog->uid == 12`.
 
-How does Extbase know what the target type of the conversion has to be? It takes this
-information from the type hint of the argument :php:`$targetType` passed to the :php:`convert` method.
-If there is nothing else declared (``$propertyMappingConfiguration``), it takes this destination type by methods of the PHP class :php:`ReflectionClass` for the parameters of the method :php:`createAction` as the target type.
-All this PHP class parsing is done in the class :php:`TYPO3\CMS\Extbase\Reflection\ClassSchema`.
+Extbase determines the target type of the conversion by the :php:`$targetType`
+passed to the :php:`convert` method. If it is not declared in the
+:php:`$propertyMappingConfiguration`, the php type of the action is used.
+
+The PHP class parsing is done in :php:`TYPO3\CMS\Extbase\Reflection\ClassSchema`.
 The type of the parameters are given in the function definition.
-For a better understanding you should keep the formerly required param notations in the comments as well:
+
+For a better understanding you may keep the formerly required
+param notations in the comments as well:
+
+.. deprecated:: 11.3
+   Using the :php:`@param` DocBlock annotation without adding the actual PHP
+   type declaration has been deprecated with TYPO3 11.3.
+
 
 .. index:: Action; Parameters
 
 ::
-
-   * @param Blog $blog The blog the post belongs to
+   /**
+    * @param \MyVendor\MyExtension\Blog $blog
+    */
+   public function createAction(\MyVendor\MyExtension\Blog $blog);
 
 The link is created with the name of the argument ``$blog``.
 In this way, the link between the request parameter and
@@ -307,9 +319,9 @@ This is the stripped-down method:
      *
      * @param Blog $blog The blog the post belogns to
      * @param Post $newBlog A fresh Blog object which has not yet been added to the repository
-     * @return void
+     * @return ResponseInterface
      */
-    public function createAction(Blog $blog, Post $newPost)
+    public function createAction(Blog $blog, Post $newPost) : ResponseInterface
     {
         // TODO access protection
         $blog->addPost($newPost);

--- a/Documentation/3-BlogExample/4-and-action.rst
+++ b/Documentation/3-BlogExample/4-and-action.rst
@@ -66,7 +66,7 @@ the doc comments and some methods have been removed. Find the full example at
       public function createAction(Blog $newBlog): ResponseInterface
       {
          $this->blogRepository->add($newBlog);
-         $this->redirect('index');
+         return $this->redirect('index');
       }
 
       public function editAction(Blog $blog): ResponseInterface
@@ -82,13 +82,13 @@ the doc comments and some methods have been removed. Find the full example at
       public function updateAction(Blog $blog): ResponseInterface
       {
          $this->blogRepository->update($blog);
-         $this->redirect('index');
+         return $this->redirect('index');
       }
 
       public function deleteAction(Blog $blog): ResponseInterface
       {
          $this->blogRepository->remove($blog);
-         $this->redirect('index');
+         return $this->redirect('index');
       }
    }
 

--- a/Documentation/3-BlogExample/4-and-action.rst
+++ b/Documentation/3-BlogExample/4-and-action.rst
@@ -63,7 +63,7 @@ the doc comments and some methods have been removed. Find the full example at
          return $this->responseFactory->createHtmlResponse($this->view->render());
       }
 
-      public function createAction(Blog $newBlog): void
+      public function createAction(Blog $newBlog): ResponseInterface
       {
          $this->blogRepository->add($newBlog);
          $this->redirect('index');
@@ -79,13 +79,13 @@ the doc comments and some methods have been removed. Find the full example at
          return $this->responseFactory->createHtmlResponse($this->view->render());
       }
 
-      public function updateAction(Blog $blog): void
+      public function updateAction(Blog $blog): ResponseInterface
       {
          $this->blogRepository->update($blog);
          $this->redirect('index');
       }
 
-      public function deleteAction(Blog $blog): void
+      public function deleteAction(Blog $blog): ResponseInterface
       {
          $this->blogRepository->remove($blog);
          $this->redirect('index');
@@ -94,18 +94,18 @@ the doc comments and some methods have been removed. Find the full example at
 
 The method `indexAction()` within the
 :php:`BlogController` is responsible for showing a list of
-blogs. The `indexAction` has to return an implementation 
-of the :php:\Psr\Http\Message\ResponseInterface`. 
+blogs. The `indexAction` has to return an implementation
+of the :php:\Psr\Http\Message\ResponseInterface`.
 
-`newAction()` shows a form to create a new blog. The 
-`createAction()` then creates a new blog with the data of the form. 
+`newAction()` shows a form to create a new blog. The
+`createAction()` then creates a new blog with the data of the form.
 
 The `editAction()` and `updateAction()` have similar functionality for the
 change of an existing blog.
 
 The job of the `deleteAction()` should be self explaining.
 
-The function names can be chosen freely but have to end on "Action". 
+The function names can be chosen freely but have to end on "Action".
 This helps Extbase to recognize them as an action. For example  `indexAction()`
 could also be called  `showTheListAction()`.
 

--- a/Documentation/4-FirstExtension/5-controlling-the-flow.rst
+++ b/Documentation/4-FirstExtension/5-controlling-the-flow.rst
@@ -39,9 +39,9 @@ The controller looks like this:
       private $productRepository;
 
       /**
-      * Inject the product repository
+      * Injects the product repository
       *
-      * @param \MyVendor\StoreInventory\Domain\Repository\ProductRepository $productRepository
+      * @param ProductRepository $productRepository
       */
       public function injectProductRepository(ProductRepository $productRepository)
       {
@@ -90,7 +90,7 @@ Fetching the products from the repository
 
 As a list of all products should be displayed in our inventory,
 the method :php:`findAll()` of the repository is used to fetch them.
-:php:`findAll()` is  implemented in class :php:`\TYPO3\CMS\Extbase\Persistence\Repository`, 
+:php:`findAll()` is  implemented in class :php:`\TYPO3\CMS\Extbase\Persistence\Repository`,
 the parent class of our repository.
 
 

--- a/Documentation/5-Domain/2-implementing-the-domain-model.rst
+++ b/Documentation/5-Domain/2-implementing-the-domain-model.rst
@@ -383,16 +383,16 @@ annotations:
 
 By default, Extbase invites all child objects with the parent object (so for
 example, all offers of an organization). This behavior is called Eager-Loading.
-The annotation :php:`@TYPO3\CMS\Extbase\Annotation\ORM\Lazy` causes Extbase to 
+The annotation :php:`@TYPO3\CMS\Extbase\Annotation\ORM\Lazy` causes Extbase to
 load and build the objects only when they
 are actually needed (lazy loading). This can lead to a significant
 increase in speed in scenarios with big data records,
-for example, many organizations, each with many offers. 
+for example, many organizations, each with many offers.
 
 .. note::
 
    Beware of using all properties provided by child objects with
-   :php:`@TYPO3\CMS\Extbase\Annotation\ORM\Lazy`, because these annotations 
+   :php:`@TYPO3\CMS\Extbase\Annotation\ORM\Lazy`, because these annotations
    can lead to frequent loading of child objects.
    The ensuing small-scale accesses of the database reduce the performance and will cause the exact
    opposite of what you wanted to achieve with the lazy-loading.
@@ -549,7 +549,7 @@ emphasizes some peculiarities.
         *
         * @param string $title
         */
-       public function __construct($title)
+       public function __construct(string $title)
        {
            $this->setTitle($title);
            $this->setAttendanceFees(new \TYPO3\CMS\Extbase\Persistence\ObjectStorage);
@@ -646,7 +646,7 @@ The class RangeConstraint looks as follows (Comments were partly removed):
        * @param int $minimumValue
        * @param int $maximumValue
        */
-      public function __construct($minimumValue = null, $maximumValue = null)
+      public function __construct(int $minimumValue = null, int $maximumValue = null)
       {
          $this->setMinimumValue($minimumValue);
          $this->setMaximumValue($maximumValue);
@@ -656,7 +656,7 @@ The class RangeConstraint looks as follows (Comments were partly removed):
        * @param mixed The minimum value
        * @return void
        */
-      public function setMinimumValue($minimumValue = null)
+      public function setMinimumValue(mixed $minimumValue = null)
       {
          $this->minimumValue = $this->normalizeValue($minimumValue);
       }
@@ -670,7 +670,7 @@ The class RangeConstraint looks as follows (Comments were partly removed):
        * @param mixed The maximum value
        * @return void
        */
-      public function setMaximumValue($maximumValue = null)
+      public function setMaximumValue(mixed $maximumValue = null)
       {
          $this->maximumValue = $this->normalizeValue($maximumValue);
       }

--- a/Documentation/6-Persistence/2a-creating-the-repositories.rst
+++ b/Documentation/6-Persistence/2a-creating-the-repositories.rst
@@ -301,20 +301,22 @@ by the ObjectManager or via dependency injection first.
    :caption: Dependency injection example from chapter 2
    :name:
 
-    /**
-     * @var ProductRepository
-     */
-    private $productRepository;
+   // use \MyVendor\StoreInventory\Domain\Repository\ProductRepository
 
-    /**
-     * Inject the product repository
-     *
-     * @param \MyVendor\StoreInventory\Domain\Repository\ProductRepository $productRepository
-     */
-    public function injectProductRepository(ProductRepository $productRepository)
-    {
-        $this->productRepository = $productRepository;
-    }
+   /**
+   * @var ProductRepository
+   */
+   private $productRepository;
+
+   /**
+   * Inject the product repository
+   *
+   * @param ProductRepository $productRepository
+   */
+   public function injectProductRepository(ProductRepository $productRepository)
+   {
+      $this->productRepository = $productRepository;
+   }
 
 
 .. warning::

--- a/Documentation/6-Persistence/3-implement-individual-database-queries.rst
+++ b/Documentation/6-Persistence/3-implement-individual-database-queries.rst
@@ -76,7 +76,7 @@ More repository search methods are available:
      * @return object The matching object if found, otherwise NULL
      * @api
      */
-    public function findByUid($uid)
+    public function findByUid(int $uid)
     {
         return $this->findByIdentifier($uid);
     }
@@ -86,11 +86,11 @@ More repository search methods are available:
     /**
      * Finds an object matching the given identifier.
      *
-     * @param int $uid The identifier of the object to find
+     * @param int $identifier The identifier of the object to find
      * @return object The matching object if found, otherwise NULL
      * @api
      */
-    public function findByIdentifier($identifier)
+    public function findByIdentifier(int $identifier)
     {
         return $this->persistenceManager->getObjectByIdentifier($identifier, $this->objectType);
     }

--- a/Documentation/7-Controllers/1-Creating-Controllers-and-Actions.rst
+++ b/Documentation/7-Controllers/1-Creating-Controllers-and-Actions.rst
@@ -285,7 +285,7 @@ Form data. If all Arguments are valid, the action
    {
       $organization->addOffer($newOffer);
       $newOffer->setOrganization($organization);
-      $this->redirect('show', 'Organization', NULL, ['organization' => $organization]);
+      return $this->redirect('show', 'Organization', NULL, ['organization' => $organization]);
    }
 
 The new offer is allocated to the organization, and inversely the
@@ -506,8 +506,7 @@ offers.
    public function updateAction(Offer $offer) : ResponseInterface
    {
       $this->offerRepository->update($offer);
-      $this->redirect('show', 'Organization', NULL, ['organization' => $offer->getOrganization()]);
-      return $this->htmlResponse();
+      return $this->redirect('show', 'Organization', NULL, ['organization' => $offer->getOrganization()]);
    }
 
 .. warning::
@@ -559,7 +558,7 @@ Let's look at an example with the Method
       } else {
          $this->flashMessages->add('Please sign in.');
       }
-      $this->redirect('show', 'Organization', NULL, ['organization' => $offer->getOrganization()]);
+      return $this->redirect('show', 'Organization', NULL, ['organization' => $offer->getOrganization()]);
    }
 
 A previously instantiated
@@ -714,8 +713,7 @@ Object in one single action. The appropriate Method
       } else {
          $this->flashMessages->add('Please sign in.');
       }
-      $this->redirect('show', 'Organization', NULL, ['organization' => $offer->getOrganization()]);
-      return $this->htmlResponse();
+      return $this->redirect('show', 'Organization', NULL, ['organization' => $offer->getOrganization()]);
    }
 
 The important thing here is that you delete the given Offer from the

--- a/Documentation/7-Controllers/1-Creating-Controllers-and-Actions.rst
+++ b/Documentation/7-Controllers/1-Creating-Controllers-and-Actions.rst
@@ -70,7 +70,8 @@ name of this method:
 
 .. code-block:: php
 
-   // …
+   // use \MyVendor\SjrOffers\Domain\Repository\OfferRepository;
+
    /**
     * @var OfferRepository
     */
@@ -79,7 +80,7 @@ name of this method:
    /**
     * Inject the offer repository
     *
-    * @param \MyVendor\SjrOffers\Domain\Repository\OfferRepository $offerRepository
+    * @param OfferRepository $offerRepository
     */
    public function injectOfferRepository(OfferRepository $offerRepository)
    {
@@ -132,11 +133,12 @@ be shown is passed to the method as argument:
     * Show action
     *
     * @param \MyVendor\SjrOffers\Domain\Model\Offer $offer The offer to be shown
-    * @return string The rendered HTML string
+    * @return ResponseInterface The rendered HTML string
     */
    public function showAction(\MyVendor\SjrOffers\Domain\Model\Offer $offer)
    {
       $this->view->assign('offer', $offer);
+      return $this->htmlResponse();
    }
 
 Usually, the display of a single Object is called by a link in the
@@ -158,9 +160,10 @@ that the GET Argument `tx_sjroffers_pi1[offer]=3` corresponds to the method argu
 :php:`showAction(\MyVendor\SjrOffers\Domain\Model\Offer *$offer*)`.
 Extbase fetches the type of this Argument from the method signature:
 :php:`showAction(*\MyVendor\SjrOffers\Domain\Model\Offer* $offer)`.
-In case this so called *Type Hint* should not be present,
-Extbase reads the type from the annotation written above the method:
-:php:`@param *\MyVendor\SjrOffers\Domain\Model\Offer* $offer`.
+
+.. deprecated:: 11.3
+   Starting with TYPO3 11.3 omitting the PHP type declaration and only using
+   the DocBlock annotation :php:`@param` has been deprecated.
 
 After successfully assigning, the incoming argument's value has
 to be cast in the target type and checked for validity (read more
@@ -230,18 +233,20 @@ method :php:`newAction()`.
    use Psr\Http\Message\ResponseInterface;
    use TYPO3\CMS\Extbase\Annotation as Extbase;
    use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+   use MyVendor\SjrOffers\Domain\Model\Organization;
+   use \MyVendor\SjrOffers\Domain\Model\Offer;
 
    class OfferController extends ActionController
    {
       // ...
 
       /**
-       * @param \MyVendor\SjrOffers\Domain\Model\Organization $organization The organization
-       * @param \MyVendor\SjrOffers\Domain\Model\Offer $offer The new offer object
+       * @param Organization $organization The organization
+       * @param Offer $offer The new offer object
        * @return ResponseInterface An HTML form for creating a new offer
        * @Extbase\IgnoreValidation("newOffer")
        */
-      public function newAction(\MyVendor\SjrOffers\Domain\Model\Organization $organization, \MyVendor\SjrOffers\Domain\Model\Offer $newOffer = null): ResponseInterface
+      public function newAction(Organization $organization, Offer $newOffer = null): ResponseInterface
       {
          $this->view->assign('organization', $organization);
          $this->view->assign('newOffer', $newOffer);
@@ -268,12 +273,15 @@ Form data. If all Arguments are valid, the action
 
 .. code-block:: php
 
+   // use \MyVendor\SjrOffers\Domain\Model\Organization;
+   // use \MyVendor\SjrOffers\Domain\Model\Offer
+
    /**
-    * @param \MyVendor\SjrOffers\Domain\Model\Organization $organization The organization the offer belongs to
-    * @param \MyVendor\SjrOffers\Domain\Model\Offer $newOffer A fresh Offer object which has not yet been added to the repository
-    * @return void
+    * @param Organization $organization The organization the offer belongs to
+    * @param Offer $newOffer A fresh Offer object which has not yet been added to the repository
+    * @return ResponseInterface
     */
-   public function createAction(\MyVendor\SjrOffers\Domain\Model\Organization $organization, \MyVendor\SjrOffers\Domain\Model\Offer $newOffer)
+   public function createAction(Organization $organization, Offer $newOffer) : ResponseInterface
    {
       $organization->addOffer($newOffer);
       $newOffer->setOrganization($organization);
@@ -459,17 +467,18 @@ be edited as an argument.
    use Psr\Http\Message\ResponseInterface;
    use TYPO3\CMS\Extbase\Annotation as Extbase;
    use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+   use MyVendor\SjrOffers\Domain\Model\Offer;
 
    class OfferController extends ActionController
    {
       // ...
 
       /**
-       * @param \MyVendor\SjrOffers\Domain\Model\Offer $offer The existing, unmodified offer
-       * @return string Form for editing the existing organization
+       * @param Offer $offer The existing, unmodified offer
+       * @return ResponseInterface
        * @Extbase\IgnoreValidation("offer")
        */
-      public function editAction(\MyVendor\SjrOffers\Domain\Model\Offer $offer): ResponseInterface
+      public function editAction(Offer $offer): ResponseInterface
       {
          $this->view->assign('offer', $offer);
          $this->view->assign('regions', $this->regionRepository->findAll());
@@ -488,14 +497,17 @@ offers.
 
 .. code-block:: php
 
+   // use \MyVendor\SjrOffers\Domain\Model\Offer;
+
    /**
-    * @param \MyVendor\SjrOffers\Domain\Model\Offer $offer The modified offer
-    * @return void
+    * @param Offer $offer The modified offer
+    * @return ResponseInterface
     */
-   public function updateAction(\MyVendor\SjrOffers\Domain\Model\Offer $offer)
+   public function updateAction(Offer $offer) : ResponseInterface
    {
       $this->offerRepository->update($offer);
       $this->redirect('show', 'Organization', NULL, ['organization' => $offer->getOrganization()]);
+      return $this->htmlResponse();
    }
 
 .. warning::
@@ -658,7 +670,7 @@ located in :file:`EXT:sjr_offers/Classes/ViewHelpers/Security/`.
        * @param mixed $person The person to be tested for login
        * @return string The output
        */
-      public function render($person = NULL)
+      public function render(mixed $person = NULL)
       {
          $accessControlService = GeneralUtility::makeInstance(AccessControlService::class);
          if ($accessControlService->isLoggedIn($person)) {
@@ -688,11 +700,13 @@ Object in one single action. The appropriate Method
 
 .. code-block:: php
 
+   // use \MyVendor\SjrOffers\Domain\Model\Offer
+
    /**
-    * @param \MyVendor\SjrOffers\Domain\Model\Offer $offer The offer to be deleted
-    * @return void
+    * @param Offer $offer The offer to be deleted
+    * @return ResponseInterface
     */
-   public function deleteAction(\MyVendor\SjrOffers\Domain\Model\Offer $offer)
+   public function deleteAction(Offer $offer) : ResponseInterface
    {
       $administrator = $offer->getOrganization()->getAdministrator();
       if ($this->accessControlService->isLoggedIn($administrator)) {
@@ -701,6 +715,7 @@ Object in one single action. The appropriate Method
          $this->flashMessages->add('Please sign in.');
       }
       $this->redirect('show', 'Organization', NULL, ['organization' => $offer->getOrganization()]);
+      return $this->htmlResponse();
    }
 
 The important thing here is that you delete the given Offer from the
@@ -724,11 +739,13 @@ stage":
 
 .. code-block:: php
 
+   // use \MyVendor\SjrOffers\Domain\Model\Demand;
+
    /**
-    * @param \MyVendor\SjrOffers\Domain\Model\Demand $demand A demand (filter)
-    * @return string The rendered HTML string
+    * @param Demand $demand A demand (filter)
+    * @return ResponseInterface
     */
-   public function indexAction(\MyVendor\SjrOffers\Domain\Model\Demand $demand = NULL): ResponseInterface
+   public function indexAction(Demand $demand = NULL): ResponseInterface
    {
       $allowedStates = (strlen($this->settings['allowedStates']) > 0) ?
             t3lib_div::intExplode(',', $this->settings['allowedStates']) : [];

--- a/Documentation/8-Fluid/10-template-creation-by-example.rst
+++ b/Documentation/8-Fluid/10-template-creation-by-example.rst
@@ -131,20 +131,21 @@ The `NumericRangeViewHelper` is implemented as follows:
    namespace MyVendor\SjrOffers\ViewHelpers\Format;
 
    use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+   use MyVendor\SjrOffers\Domain\Model\NumericRangeInterface;
 
    class NumericRangeViewHelper extends AbstractViewHelper
    {
      /**
-      * @param \MyVendor\SjrOffers\Domain\Model\NumericRangeInterface $range The range
+      * @param \NumericRangeInterface $range The range
       * @return string Formatted range
       */
-     public function render(\MyVendor\SjrOffers\Domain\Model\NumericRangeInterface $range = NULL)
+     public function render(NumericRangeInterface $range = NULL)
      {
        $output = '';
        if ($range === NULL) {
          $range = $this->renderChildren();
        }
-       if ($range instanceof \MyVendor\SjrOffers\Domain\Model\NumericRangeInterface) {
+       if ($range instanceof NumericRangeInterface) {
          $minimumValue = $range->getMinimumValue();
          $maximumValue = $range->getMaximumValue();
          if (empty($minimumValue) && !empty($maximumValue)) {

--- a/Documentation/9-CrosscuttingConcerns/2-validating-domain-objects.rst
+++ b/Documentation/9-CrosscuttingConcerns/2-validating-domain-objects.rst
@@ -40,31 +40,9 @@ Validators for checking of invariants
 
 A validator is a PHP class that has to check a certain invariant. All
 validators that are used in Extbase extensions have to implement the interface
-:php:`\TYPO3\CMS\Extbase\Validation\Validator\ValidatorInterface`::
+:php:`ValidatorInterface`:
 
-    namespace TYPO3\CMS\Extbase\Validation\Validator;
-
-    /**
-    * Contract for a validator
-    */
-    interface ValidatorInterface
-    {
-        /**
-        * Checks if the given value is valid according to the validator, and returns
-        * an Error Result object.
-        *
-        * @param mixed $value The value that should be validated
-        * @return \TYPO3\CMS\Extbase\Error\Result
-        */
-        public function validate($value);
-
-        /**
-        * Returns the options of this validator which can be specified in the constructor
-        *
-        * @return array
-        */
-        public function getOptions();
-    }
+.. include:: /CodeSnippets/StyleguideCode/ValidatorInterface.rst.txt
 
 This interface requires validators to implement two methods:
 
@@ -446,10 +424,10 @@ below it is ``$pageName`` :php:`\MyVendor\MyExtension\Domain\Validator\PagenameV
     /**
      * Creates a new page with a given name.
      *
-     * @param string $pageName THe name of the page which should be created.
+     * @param string $pageName The name of the page which should be created.
      * @TYPO3\CMS\Extbase\Annotation\Validate("MyVendor\MyExtension\Domain\Validator\PageNameValidator", param="pageName")
      */
-    public function createPageAction($pageName): ResponseInterface
+    public function createPageAction(string $pageName): ResponseInterface
     {
         // ...
     }
@@ -472,18 +450,20 @@ called:
 Let's have a look at the interaction once more with an
 example::
 
-    /**
-     * Creates a website user for the given page name.
-     *
-     * @param string $pageName The name of the page where the user should be created.
-     * @param \MyVendor\ExtbaseExample\Domain\Model\User $user The user which should be created.
-     * @TYPO3\CMS\Extbase\Annotation\Validate(param="pageName", validator="TYPO3\CMS\Extbase\Validation\Validator\StringValidator")
-     * @TYPO3\CMS\Extbase\Annotation\Validate("MyVendor\BlogExample\Domain\Validator\CustomUserValidator", param="user")
-     */
-    public function createUserAction($pageName, \MyVendor\ExtbaseExample\Domain\Model\User $user): ResponseInterface
-    {
-        // ...
-    }
+   // use TYPO3\CMS\Extbase\Annotation\Validate;
+   // use MyVendor\ExtbaseExample\Domain\Model\User;
+   /**
+   * Creates a website user for the given page name.
+   *
+   * @param string $pageName The name of the page where the user should be created.
+   * @param User $user The user which should be created.
+   * @Validate(param="pageName", validator="TYPO3\CMS\Extbase\Validation\Validator\StringValidator")
+   * @Validate("MyVendor\BlogExample\Domain\Validator\CustomUserValidator", param="user")
+   */
+   public function createUserAction(string $pageName, User $user): ResponseInterface
+   {
+     // ...
+   }
 
 For ``$user`` all ``@TYPO3\CMS\Extbase\Annotation\Validate`` annotations of the model are validated. Beyond that, the validator
 ``\MyVendor\BlogExample\Domain\Validator\CustomUserValidator`` is used
@@ -666,6 +646,7 @@ code:
       public function createAction(\MyVendor\BlogExample\Domain\Model\Blog $newBlog): ResponseInterface
       {
          $this->blogRepository->add($newBlog);
+         return $this->htmlResponse();
       }
    }
 

--- a/Documentation/CodeSnippets/StyleguideCode/ValidatorInterface.rst.txt
+++ b/Documentation/CodeSnippets/StyleguideCode/ValidatorInterface.rst.txt
@@ -1,0 +1,28 @@
+.. Automatic screenshot: Remove this line if you want to manually change this file
+
+.. code-block:: php
+   :caption: \TYPO3\CMS\Extbase\Validation\Validator\ValidatorInterface
+
+   namespace TYPO3\CMS\Extbase\Validation\Validator;
+
+   /**
+    * Contract for a validator
+    */
+   interface ValidatorInterface
+   {
+       /**
+        * Checks if the given value is valid according to the validator, and returns
+        * the Error Messages object which occurred.
+        *
+        * @param mixed $value The value that should be validated
+        * @return \TYPO3\CMS\Extbase\Error\Result
+        */
+       public function validate($value);
+
+       /**
+        * Returns the options of this validator which can be specified in the constructor
+        *
+        * @return array
+        */
+       public function getOptions();
+   }

--- a/Documentation/b-ExtbaseReference/Index.rst
+++ b/Documentation/b-ExtbaseReference/Index.rst
@@ -553,34 +553,35 @@ of the specified method, as shown in Example B-3:
 
    use TYPO3\CMS\Extbase\Annotation as Extbase;
    use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+   use Ex\BlogExample\Domain\Model\Blog
 
    class BlogController extends ActionController
    {
        /**
         * Displays a form for creating a new blog, optionally pre-filled with partial information.
         *
-        * @param \Ex\BlogExample\Domain\Model\Blog $newBlog A fresh blog object which should be taken
+        * @param Blog $newBlog A fresh blog object which should be taken
         *        as a basis for the form if it is set.
         *
-        * @return void
+        * @return ResponseInterface
         *
         * @Extbase\IgnoreValidation("newBlog")
         */
-       public function newAction(\Ex\BlogExample\Domain\Model\Blog $newBlog = NULL)
+       public function newAction(Blog $newBlog = NULL) : ResponseInterface
        {
            $this->view->assign('newBlog', $newBlog);
+           return $this->htmlResponse();
        }
    }
 
-It is important to specify the full type in the `@param` annotation as this is used to validate
-the object. Note that not only simple data types such as String, Integer, or Float can be validated,
-but also complex object types (see also the section ":ref:`validating-domain-objects`" in Chapter 9).
+.. note::
+   Not only simple data types such as String, Integer, or Float can be validated,
+   but also complex object types (see also the section
+   ":ref:`validating-domain-objects`" in Chapter 9).
 
-.. todo: It's neither true that users need an `@param`, nor is it true that users need to use the FQCN.
-
-Besides, on actions showing the forms used to create domain objects, the validation of domain
-objects must be explicitly disabled - therefore, the annotation
-:php:`@TYPO3\CMS\Extbase\Annotation\IgnoreValidation` is necessary.
+The validation of domain object can be explicitly disabled by the annotation
+:php:`@TYPO3\CMS\Extbase\Annotation\IgnoreValidation`. This might be necessary
+in actions that show forms or create domain objects.
 
 Default values can, as usual in PHP, just be indicated in the method signature. In the above case,
 the default value of the parameter `$newBlog` is set to NULL. If an action returns `NULL` or nothing,
@@ -855,14 +856,17 @@ to formulate a request:
 
 ::
 
+   // use TYPO3\CMS\Extbase\Persistence\Generic\QueryResult;
+   // use Ex\BlogExample\Domain\Model\Category;
+
     /**
      * Find blogs, which have the given category.
      *
-     * @param \Ex\BlogExample\Domain\Model\Category $category
+     * @param Category $category
      *
-     * @return \TYPO3\CMS\Extbase\Persistence\Generic\QueryResult
+     * @return QueryResult
      */
-    public function findWithCategory(\Ex\BlogExample\Domain\Model\Category $category)
+    public function findWithCategory(Category $category) : QueryResult
     {
         $query = $this->createQuery();
         $query->matching($query->contains('categories', $category));

--- a/screenshots.json
+++ b/screenshots.json
@@ -1,0 +1,17 @@
+{
+    "suites": {
+        "Core": {
+            "screenshots": {
+                "codeSnippets": [
+                    {"action": "setCodeSnippetsTargetPath", "path": "CodeSnippets/StyleguideCode"},
+                    {
+                        "action": "createCodeSnippet",
+                        "caption": "\\TYPO3\\CMS\\Extbase\\Validation\\Validator\\ValidatorInterface",
+                        "sourceFile": "typo3/sysext/extbase/Classes/Validation/Validator/ValidatorInterface.php",
+                        "targetFileName": "ValidatorInterface"
+                    }
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
[Deprecation] #94115 - Parameter Type Evaluation via DocBlock comments
[Deprecation] #94351 - ext:extbase StopActionException

These deprecations touch much of the same code and therefore have to be handled in a combined PR

refs https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/1395