### PR TITLE
Instantiation of the class Typo3QuerySettings

### DIFF
--- a/Documentation/6-Persistence/2a-creating-the-repositories.rst
+++ b/Documentation/6-Persistence/2a-creating-the-repositories.rst
@@ -180,9 +180,9 @@ it via the public function :php:`setDefaultQuerySettings()` from the function
 
 Here is an example::
 
+   use TYPO3\CMS\Core\Utility\GeneralUtility;
    use TYPO3\CMS\Extbase\Persistence\Repository;
    use TYPO3\CMS\Extbase\Persistence\Generic\Typo3QuerySettings;
-   use TYPO3\CMS\Core\Utility\GeneralUtility;
 
    class ExampleRepository extends Repository {
 


### PR DESCRIPTION
The Instantiation of the class Typo3QuerySettings has been changed because it comes with two mandatory parameters. If it is not called via GeneralUtility:makeinstance, the DI won't get triggered and as a result TYPO3 does not require the parameters. This leads to an exception regarding the missing parameters