### PR TITLE
Corrected mistakes in some rst-files

### DIFF
--- a/Documentation/2-BasicPrinciples/1-Model-View-Controller-in-Extbase.rst
+++ b/Documentation/2-BasicPrinciples/1-Model-View-Controller-in-Extbase.rst
@@ -124,9 +124,7 @@ As the first request is completely dispatched, the user has a list of all
 blog posts displayed in the browser. Now the user clicks on a single
 blog post and gets the complete blog post.
 Besides, the user can add a comment to this post.
-With the help of figure 2-6 we want to understand how the comment is stored.
-
-.. todo: figure 2-6 does not exist, should be 2-3, I guess.
+With the help of figure 2-3 we want to understand how the comment is stored.
 
 When submitting the comment form, the user creates a new request (1)
 containing the according controller and action.

--- a/Documentation/3-BlogExample/11-Alternative-route-creating-a-new-posting.rst
+++ b/Documentation/3-BlogExample/11-Alternative-route-creating-a-new-posting.rst
@@ -105,7 +105,6 @@ post object. They have to be created after submission of the form. Actually the 
 The ``PostController``, which is derived from ``\FriendsOfTYPO3\BlogExample\Controller\AbstractController``
 and its parents ``\TYPO3\CMS\Extbase\Mvc\Controller\ActionController`` and ``\TYPO3\CMS\Extbase\Mvc\Controller\AbstractController``,
 prepares all parameters, before an action method is called.
-instance of the class :php:`\TYPO3\CMS\Extbase\Property\PropertyMapper`, that has mainly two functions: it
 The controller method :php:`mapRequestArgumentsToControllerArguments` calls the method :php:`setValue` in a loop for each parameter.
 This method delegates the conversion to an
 instance of the class :php:`\TYPO3\CMS\Extbase\Property\PropertyMapper`, that has mainly two functions: it
@@ -136,6 +135,7 @@ param notations in the comments as well:
 .. index:: Action; Parameters
 
 ::
+
    /**
     * @param \MyVendor\MyExtension\Blog $blog
     */

--- a/Documentation/3-BlogExample/2-the-stations-of-the-journey.rst
+++ b/Documentation/3-BlogExample/2-the-stations-of-the-journey.rst
@@ -30,8 +30,8 @@ but hands over the control to the Extbase *Dispatcher*
 TYPO3 calls Extbase's Bootstrap, which then uses a RequestBuilder to create an Extbase Request.
 Then Extbase tries to find a suitable RequestHandler which then uses a class called Dispatcher.
 
-, which just creates the Controller instance and calls
-         processRequest().
+.. todo: determine whether to include following text-snippet:
+   ", which just creates the Controller instance and calls processRequest()."
 
 The *Dispatcher* handles all bundled information in the
 request object and hands it over to the extension. Depending on the action parameter of the url,

--- a/Documentation/3-BlogExample/4-and-action.rst
+++ b/Documentation/3-BlogExample/4-and-action.rst
@@ -16,14 +16,15 @@ of the :php:`BlogController` is at
 
 In software development, there are different variants of controllers.
 In Extbase, the controllers mostly exist as
-.. todo: mostly -> only, will change in the future when ActionController will be optional or replaced by traits. Also Middlewares will have controllers.
-
 :php:`ActionController`. This variant is characterized by
 short methods, which are responsible for the control of a single action, the
 so called `Actions`. Let's have a deeper look at a
 shortened version of the :php:`BlogController`. Please note that for brevity
 the doc comments and some methods have been removed. Find the full example at
 :file:`EXT:blog_example/Classes/BlogController.php`:
+
+.. todo: mostly -> only (referring to 'the controllers mostly exist as'),
+   will change in the future when ActionController will be optional or replaced by traits. Also Middlewares will have controllers.
 
 .. code-block:: php
    :caption: Classes/BlogController.php
@@ -92,10 +93,19 @@ the doc comments and some methods have been removed. Find the full example at
       }
    }
 
+.. index::
+   BlogController; indexAction
+   BlogController; newAction
+   BlogController; createAction
+   BlogController; editAction
+   BlogController; updateAction
+   BlogController; deleteAction
+   BlogController; showTheListAction
+
 The method `indexAction()` within the
 :php:`BlogController` is responsible for showing a list of
 blogs. The `indexAction` has to return an implementation
-of the :php:\Psr\Http\Message\ResponseInterface`.
+of the :php:`\Psr\Http\Message\ResponseInterface`.
 
 `newAction()` shows a form to create a new blog. The
 `createAction()` then creates a new blog with the data of the form.
@@ -109,29 +119,6 @@ The function names can be chosen freely but have to end on "Action".
 This helps Extbase to recognize them as an action. For example  `indexAction()`
 could also be called  `showTheListAction()`.
 
-
-.. index::
-   BlogController; indexAction
-   BlogController; showMeTheListAction
-   BlogController; newAction
-   BlogController; createAction
-   BlogController; editAction
-   BlogController; updateAction
-   BlogController; deleteAction
-
-The method `indexAction()` within the
-:php:`BlogController` is responsible for showing a list of
-blogs. We also could have called it
-`showMeTheListAction()`. The only important point is
-that the method name ends with `Action`, because this is a requirement from Extbase to
-recognize it as an action. `newAction()` shows a
-form to create a new blog. The `createAction()` then
-creates a new blog with the data of the form. The pair
-`editAction()` and
-`updateAction()` has similar functionality for the
-change of an existing blog. The job of the
-`deleteAction()` should be self explaining.
-
 .. index:: Extbase; Slim controller
 
 .. tip::
@@ -142,11 +129,12 @@ change of an existing blog. The job of the
    exclusively responsible for the control of the process flow. Additional
    logic (especially business or domain logic) needs to be separated into
    classes in the subfolder :file:`Domain`.
+   
    .. todo: We should also mention Services and Middlewares here. The domain only holds the
             business logic, not all the application logic.
 
 The request determines which controller action combination will be called.
-The dispatching and matching of actions happen in the `RequestBuilder`, in the Dispatcher` and in
+The dispatching and matching of actions happen in the `RequestBuilder`, in the `Dispatcher` and in
 :php:`\TYPO3\CMS\Extbase\Mvc\Controller\ActionController`. The BlogController
 inherits all methods from it by deriving it from this class ::
 

--- a/Documentation/3-BlogExample/5-Get-Blog-from-the-Repository.rst
+++ b/Documentation/3-BlogExample/5-Get-Blog-from-the-Repository.rst
@@ -32,7 +32,7 @@ blog objects, which is one of the methods available by default.
    class.
 
 
-..index:: Extbase; Repositories
+.. index:: Extbase; Repositories
 
 How repositories work
 =====================


### PR DESCRIPTION
I got to read this documentation recently and came across several ugly mistakes.
This pull-request attempts to address the following issues that were found in the 'Introduction'-section of the HTML-docs:
- missing whitespace in the rst-sources that caused things like rst-comments showing up as visible content in the rendered HTML
- some duplicated content

releases: master, 11.5