### PR TITLE
Breaking: #96044 - Harden method signature of logicalAnd() and logica…

### DIFF
--- a/Documentation/6-Persistence/3-implement-individual-database-queries.rst
+++ b/Documentation/6-Persistence/3-implement-individual-database-queries.rst
@@ -279,7 +279,7 @@ In the method ``findDemanded()`` of the ``offerRepository``, the request is impl
 The ``Demand`` object is passed as an argument. In the first line, the ``Query`` object is created.
 All single constraint terms are then collected in the array ``$constraints``. The
 ``$query->logicalAnd(...$constraints)`` instruction brings together these constraint terms
-if there are more then one, and
+if there are more than one and
 they are assigned to the ``Query`` object via ``matching()``. With ``return $query->execute();``, the
 query is executed, and the located ``Offer`` objects are returned to the caller.
 

--- a/Documentation/6-Persistence/3-implement-individual-database-queries.rst
+++ b/Documentation/6-Persistence/3-implement-individual-database-queries.rst
@@ -200,8 +200,7 @@ object of ``logicalAnd()`` is true if both given parameters ``$constraint1`` and
 be true if only one of the given parameters is true. Both methods
 require at least two parameters and accept an infinite number of parameters.
 
-Last but not least, the function
-``logicalNot()`` inverts the given ``$constraint`` to its opposite, i.e. *true*
+The function ``logicalNot()`` inverts the given ``$constraint`` to its opposite, i.e. *true*
 yields *false* and *false* yields *true*. Given this information, you can create
 complex queries such as:
 

--- a/Documentation/b-ExtbaseReference/Index.rst
+++ b/Documentation/b-ExtbaseReference/Index.rst
@@ -936,9 +936,9 @@ Since 1.1 (TYPO3 4.3), `$propertyName` is not necessarily only a simple property
 
 `$query->logicalOr($constraint1, $constraint2);`
    Two conditions are joined with a logical *or*, that returns a condition.
-   A minimum of two paramaters are allowed. As of TYPO3 version 12, passing the
+   A minimum of two parameters are allowed. As of TYPO3 version 12, passing the
    parameters as an array is not allowed. For a migration, check the
-   the description above for :php:`logicalAnd`.
+   description above for :php:`logicalAnd`.
 
 `$query->logicalNot($constraint);`
     Returns a condition that inverts the result of the given condition (logical *not*).

--- a/Documentation/b-ExtbaseReference/Index.rst
+++ b/Documentation/b-ExtbaseReference/Index.rst
@@ -486,8 +486,8 @@ Most important API methods of action controller
 -----------------------------------------------
 
 .. deprecated:: 11.5
-   The method :php:`initializeView` has been deprecated and will be removed along with the 
-   :php:`\TYPO3\CMS\Extbase\Mvc\View\ViewInterface` in v12. 
+   The method :php:`initializeView` has been deprecated and will be removed along with the
+   :php:`\TYPO3\CMS\Extbase\Mvc\View\ViewInterface` in v12.
 
 `Action()`
     Defines an action.
@@ -911,12 +911,34 @@ Since 1.1 (TYPO3 4.3), `$propertyName` is not necessarily only a simple property
     "tools" assigned. If necessary, you can combine multiple conditions with boolean operations.
 
 `$query->logicalAnd($constraint1, $constraint2);`
-    Two conditions are joined with a logical *and*, it gives back the resulting condition. Since Extbase
-    1.1 (TYPO3 4.3) also an array of conditions is allowed.
+   Two conditions are joined with a logical *and*, it gives back the resulting condition.
+   Multiple parameters are allowed, at least 2. Since TYPO3 12 passing the
+   parameters as array is not allowed anymore. Use the following migration::
+
+   $constraints = [];
+
+   if (...) {
+      $constraints[] = $query->equals('propertyName1', 'value1');
+   }
+
+   if (...) {
+      $constraints[] = $query->equals('propertyName2', 'value2');
+   }
+
+   $query = $this->createQuery();
+
+   $numberOfConstraints = count($constraints);
+   if ($numberOfConstraints === 1) {
+       $query->matching(reset($constraints));
+   } elseif ($numberOfConstraints >= 2) {
+       $query->matching($query->logicalAnd(...$constraints));
+   }
 
 `$query->logicalOr($constraint1, $constraint2);`
-    Two conditions are joined with a logical *or*, it gives back the resulting condition. Since Extbase
-    1.1 (TYPO3 4.3) also an array of conditions is allowed.
+   Two conditions are joined with a logical *or*, it gives back the resulting condition.
+   Multiple parameters are allowed, at least 2. Since TYPO3 12 passing the
+   parameters as array is not allowed anymore. For a migration have a look at
+   the above description for function :php:`logicalAnd`.
 
 `$query->logicalNot($constraint);`
     Returns a condition that inverts the result of the given condition (logical *not*).

--- a/Documentation/b-ExtbaseReference/Index.rst
+++ b/Documentation/b-ExtbaseReference/Index.rst
@@ -911,9 +911,9 @@ Since 1.1 (TYPO3 4.3), `$propertyName` is not necessarily only a simple property
     "tools" assigned. If necessary, you can combine multiple conditions with boolean operations.
 
 `$query->logicalAnd($constraint1, $constraint2);`
-   Two conditions are joined with a logical *and*, it gives back the resulting condition.
-   Multiple parameters are allowed, at least 2. Since TYPO3 12 passing the
-   parameters as array is not allowed anymore. Use the following migration::
+   Two conditions are joined with a logical *and* that returns a condition.
+   Multiple parameters are allowed, at least 2. As of TYPO3 version 12, passing the
+   parameters as an array is not allowed. Use the following migration::
 
    $constraints = [];
 
@@ -935,10 +935,10 @@ Since 1.1 (TYPO3 4.3), `$propertyName` is not necessarily only a simple property
    }
 
 `$query->logicalOr($constraint1, $constraint2);`
-   Two conditions are joined with a logical *or*, it gives back the resulting condition.
-   Multiple parameters are allowed, at least 2. Since TYPO3 12 passing the
-   parameters as array is not allowed anymore. For a migration have a look at
-   the above description for function :php:`logicalAnd`.
+   Two conditions are joined with a logical *or*, that returns a condition.
+   A minimum of two paramaters are allowed. As of TYPO3 version 12, passing the
+   parameters as an array is not allowed. For a migration, check the
+   the description above for :php:`logicalAnd`.
 
 `$query->logicalNot($constraint);`
     Returns a condition that inverts the result of the given condition (logical *not*).


### PR DESCRIPTION
…lOr()

https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-96044-HardenMethodSignatureOfLogicalAndAndLogicalOr.html

references https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/1624

releases: master