### PR TITLE
Remove return statement when a redirect is used

### DIFF
--- a/Documentation/7-Controllers/1-Creating-Controllers-and-Actions.rst
+++ b/Documentation/7-Controllers/1-Creating-Controllers-and-Actions.rst
@@ -272,9 +272,6 @@ instantiates the Object and "fills" its Properties with the appropriate
 Form data. If all Arguments are valid, the action
 :php:`createAction()` is called.
 
-.. note::
-   Redirects do not return anything, that is the reason why the following action returns void
-
 .. code-block:: php
 
    // use \MyVendor\SjrOffers\Domain\Model\Organization;
@@ -291,6 +288,9 @@ Form data. If all Arguments are valid, the action
       $newOffer->setOrganization($organization);
       $this->redirect('show', 'Organization', NULL, ['organization' => $organization]);
    }
+   
+.. note::
+   Redirects do not return anything, that is the reason why the above action returns void. This is going to be change in TYPO3 12 and it has been marked as deprecated. `Breaking: #96107 - Deprecated functionality removed <https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-96107-DeprecatedFunctionalityRemoved.html/>`__
 
 The new offer is allocated to the organization, and inversely the
 organization is allocated to the offer. Thanks to this allocation, Extbase

--- a/Documentation/7-Controllers/1-Creating-Controllers-and-Actions.rst
+++ b/Documentation/7-Controllers/1-Creating-Controllers-and-Actions.rst
@@ -272,6 +272,9 @@ instantiates the Object and "fills" its Properties with the appropriate
 Form data. If all Arguments are valid, the action
 :php:`createAction()` is called.
 
+.. note::
+   Redirects do not return anything, that is the reason why the following action returns void
+
 .. code-block:: php
 
    // use \MyVendor\SjrOffers\Domain\Model\Organization;

--- a/Documentation/7-Controllers/1-Creating-Controllers-and-Actions.rst
+++ b/Documentation/7-Controllers/1-Creating-Controllers-and-Actions.rst
@@ -280,13 +280,13 @@ Form data. If all Arguments are valid, the action
    /**
     * @param Organization $organization The organization the offer belongs to
     * @param Offer $newOffer A fresh Offer object which has not yet been added to the repository
-    * @return ResponseInterface
+    * @return void
     */
-   public function createAction(Organization $organization, Offer $newOffer) : ResponseInterface
+   public function createAction(Organization $organization, Offer $newOffer) : void
    {
       $organization->addOffer($newOffer);
       $newOffer->setOrganization($organization);
-      return $this->redirect('show', 'Organization', NULL, ['organization' => $organization]);
+      $this->redirect('show', 'Organization', NULL, ['organization' => $organization]);
    }
 
 The new offer is allocated to the organization, and inversely the

--- a/Documentation/7-Controllers/1-Creating-Controllers-and-Actions.rst
+++ b/Documentation/7-Controllers/1-Creating-Controllers-and-Actions.rst
@@ -282,7 +282,7 @@ Form data. If all Arguments are valid, the action
     * @param Offer $newOffer A fresh Offer object which has not yet been added to the repository
     * @return void
     */
-   public function createAction(Organization $organization, Offer $newOffer) : void
+   public function createAction(Organization $organization, Offer $newOffer): void
    {
       $organization->addOffer($newOffer);
       $newOffer->setOrganization($organization);

--- a/Documentation/7-Controllers/1-Creating-Controllers-and-Actions.rst
+++ b/Documentation/7-Controllers/1-Creating-Controllers-and-Actions.rst
@@ -290,7 +290,7 @@ Form data. If all Arguments are valid, the action
    }
    
 .. note::
-   Redirects do not return anything, that is the reason why the above action returns void. This is going to be change in TYPO3 12 and it has been marked as deprecated. `Breaking: #96107 - Deprecated functionality removed <https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-96107-DeprecatedFunctionalityRemoved.html/>`__
+   The redirect methods do not return any response, any method using them should return `void` accordingly. This has been `deprecated in TYPO3v11 <https://docs.typo3.org/c/typo3/cms-core/11.5/en-us/Changelog/11.0/Deprecation-92784-ExtbaseControllerActionsMustReturnResponseInterface.html>`__ and was `dropped in TYPO3v12 where every action must return a response now <https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-96107-DeprecatedFunctionalityRemoved.html>`__.
 
 The new offer is allocated to the organization, and inversely the
 organization is allocated to the offer. Thanks to this allocation, Extbase


### PR DESCRIPTION
Since redirects do not return anything, the documentation here has to be edited and return void instead.