### PR TITLE
[DOCS] Replace :ts: with :typoscript: text role

### DIFF
--- a/Documentation/10-Outlook/5-error-action.rst
+++ b/Documentation/10-Outlook/5-error-action.rst
@@ -25,7 +25,7 @@ How it works
 
 #. The default is to call :php:`errorAction()` which will:
 
-   #. Clear cache in case :ts:`persistence.enableAutomaticCacheClearing` is
+   #. Clear cache in case :typoscript:`persistence.enableAutomaticCacheClearing` is
       activated and current scope is frontend.
 
    #. Add an error :ref:`Flash Message <t3coreapi:flash-messages>`

--- a/Documentation/10-Outlook/6-dispatching.rst
+++ b/Documentation/10-Outlook/6-dispatching.rst
@@ -190,7 +190,7 @@ Arguments can be accessed through::
 In order to make arguments available within the request or for mapping, they
 need to conform to Extbase's naming standard in order to be mapped to the
 extension. The default is to prefix arguments with the plugin signature. This can be
-adjusted via TypoScript option :ts:`view.pluginNamespace`, see
+adjusted via TypoScript option :typoscript:`view.pluginNamespace`, see
 :ref:`typoscript_configuration-view`.
 
 .. todo: This is something that might be deprecated in version 11.

--- a/Documentation/8-Fluid/2-using-different-output-formats.rst
+++ b/Documentation/8-Fluid/2-using-different-output-formats.rst
@@ -69,7 +69,7 @@ You can use the following TypoScript::
 You still have to exchange *[ExtensionKey]* and *[PluginName]* with the Extension and Plugin name.
 We recommend searching for the path of your Plugin in the
 TypoScript Object Browser to avoid misspelling. Further on you have to
-explicitly set :ts:`plugin.tx_*[ExtensionKey]*.persistence.storagePid`
+explicitly set :typoscript:`plugin.tx_*[ExtensionKey]*.persistence.storagePid`
 to the number of the page containing the data to tell Extbase from which page
 the data should be read.
 

--- a/Documentation/9-CrosscuttingConcerns/1-localizing-and-internationalizing-an-extension.rst
+++ b/Documentation/9-CrosscuttingConcerns/1-localizing-and-internationalizing-an-extension.rst
@@ -546,7 +546,7 @@ TYPO3 v9 and higher
 Starting with version 9, Extbase renders the translated records in the same way TypoScript rendering does.
 
 .. note::
-   In previous version the behaviour was controllable by the feature switch :ts:`consistentTranslationOverlayHandling`
+   In previous version the behaviour was controllable by the feature switch :typoscript:`consistentTranslationOverlayHandling`
    which has been removed in newer versions.
 
 1) Setting :php:`Typo3QuerySettings->languageMode` does **not** influence how Extbase queries records.

--- a/Documentation/Includes.rst.txt
+++ b/Documentation/Includes.rst.txt
@@ -13,8 +13,6 @@
 .. role:: rst(code)
 .. role:: sep(strong)
 .. role:: sql(code)
-.. role:: ts(code)
-   :class: typoscript
 
 .. role:: tsconfig(code)
    :class: typoscript

--- a/Documentation/c-FAQ/Index.rst
+++ b/Documentation/c-FAQ/Index.rst
@@ -31,8 +31,8 @@ in your TypoScript setup like this:
        }
    }
 
-To set it only for one plugin, replace :ts:`tx_yourextension` by
-:ts:`tx_yourextension_yourplugin`. For modules it's the same syntax:
+To set it only for one plugin, replace :typoscript:`tx_yourextension` by
+:typoscript:`tx_yourextension_yourplugin`. For modules it's the same syntax:
 
 .. code-block:: ts
 


### PR DESCRIPTION
The ambiguous :ts: text role has been removed to
not confuse the writer with typescript and typoscript.

Relates: https://github.com/TYPO3-Documentation/T3DocTeam/issues/181