### PR TITLE
[DOCS] Reference manual's start page with :doc:`<manual>:Index`

### DIFF
--- a/Documentation/4-FirstExtension/4-make-products-persistent.rst
+++ b/Documentation/4-FirstExtension/4-make-products-persistent.rst
@@ -113,7 +113,7 @@ The section ``types`` defines in which sequence the table columns are rendered.
 
 .. seealso::
 
-   You can find a complete listing of all options at :ref:`TYPO3 Core APIs <t3coreapi:start>`.
+   You can find a complete listing of all options at :doc:`TYPO3 Core APIs <t3coreapi:Index>`.
 
 TYPO3 is able to group all records of an extension in the new record wizard.
 

--- a/Documentation/6-Persistence/2-configure-the-backends-inputforms.rst
+++ b/Documentation/6-Persistence/2-configure-the-backends-inputforms.rst
@@ -154,7 +154,7 @@ section); the fourth position holds extensive options which are separated
 through colons, and the last place contains information about the appearance
 (e.g., color and structure). The information at the fourth place allows the use of
 the *Rich Text Editor*. For a full list of the options, refer to the already
-mentioned TYPO3-Online documentation for the :ref:`TYPO3-Core API <t3coreapi:start>`.
+mentioned TYPO3-Online documentation for the :doc:`TYPO3-Core API <t3coreapi:Index>`.
 
 
 .. index:: TCA; palettes
@@ -533,7 +533,7 @@ Field type "user"
 
 A user generates free definable form fields that can be processed by any PHP
 function. For further information, refer to the documentation which is available
-online and to the :ref:`TYPO3-Core API <t3coreapi:start>`.
+online and to the :doc:`TYPO3-Core API <t3coreapi:Index>`.
 
 
 .. index:: Field types; flex
@@ -637,7 +637,7 @@ simple 1:n-relationship with `cd` as a foreign key.
 
 However, Extbase does not support the persistence of additional Domain data in
 the temporary table because the corresponding Domain object does not exist.
-Nevertheless, the online documentation of the :ref:`TYPO3-Core API <t3coreapi:start>` describes the
+Nevertheless, the online documentation of the :doc:`TYPO3-Core API <t3coreapi:Index>` describes the
 second, more correct option for configuring m:n-relationships within IRRE. It
 depends on a plain temporary table. The following example shows off the
 configuration of products with their according categories:


### PR DESCRIPTION
Relates: https://github.com/TYPO3-Documentation/T3DocTeam/issues/185