### PR TITLE
[TASK] #96972 - Deprecate QueryBuilder::execute()

### DIFF
--- a/Documentation/6-Persistence/3-implement-individual-database-queries.rst
+++ b/Documentation/6-Persistence/3-implement-individual-database-queries.rst
@@ -417,7 +417,7 @@ is translated by Extbase to the following query:
            ->from('tx_sjroffers_domain_model_offer')
            ->where(...)
 
-       $rows = $query->execute()->fetchAll();
+       $rows = $query->executeQuery()->fetchAllAssociative();
 
    You have to handle the creation and maintenance of the objects by yourself.
 


### PR DESCRIPTION
Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/38

Additionally, `fetchAll()` is renamed to `fetchAllAssociative()` for compatibility
with DBAL 3.2:
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-96287-DoctrineDBAL32.html