### PR TITLE
[TASK] Remove information about sjr_offers from start page

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -22,9 +22,6 @@ Developing TYPO3 Extensions with Extbase and Fluid
 
 This manual teaches how to develop TYPO3 extensions with Extbase and Fluid.
 
-The extension `sjroffers <https://github.com/martin-helmich/typo3-sjroffers>`__
-is used as an example in this book.
-
 ----
 
 **Table of Contents:**


### PR DESCRIPTION
The reason is:

- sjr_offers is one of 3 extensions used in this manual
- the information which example extensions is used is not so
  relevant
- sjr_offers is outdated (only available up to 6.2) and should
  ideally not be used at all

We cannot remove all references to sjr_offers since that is
too much woven into the examples, but we can remove it from the
start page for now.